### PR TITLE
Run `cgb-scripts` through `npx`

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,9 +3,9 @@
   "version": "1.0.0",
   "private": true,
   "scripts": {
-    "start": "cgb-scripts start",
-    "build": "cgb-scripts build",
-    "eject": "cgb-scripts eject"
+    "start": "npx cgb-scripts start",
+    "build": "npx cgb-scripts build",
+    "eject": "npx cgb-scripts eject"
   },
   "dependencies": {
     "axios": "^0.18.0",


### PR DESCRIPTION
This avoids asking people to install `cgb-scripts` globally.