### PR TITLE
EPFL gallery - remove warning

### DIFF
--- a/frontend/epfl-gallery/view.php
+++ b/frontend/epfl-gallery/view.php
@@ -57,7 +57,6 @@ function epfl_gallery_block($attr) {
 
     $output .= '<div class="gallery-nav mb-3" data-gallery="my-gallery-'.$instance.'" aria-hidden="true">';
 
-    
     /* We go through given image order */
     foreach($attr['ids'] as $post_id)
     {

--- a/frontend/epfl-gallery/view.php
+++ b/frontend/epfl-gallery/view.php
@@ -12,6 +12,10 @@ function epfl_gallery_block($attr) {
     $output = '';
     $instance=md5(implode(',', $attr) . rand());
 
+    /* For an unknown reason, this function can be called with $attr equal to an empty array... so there are
+        PHP Warnings in the logs because we are trying to access 'ids' key. */
+    if(!array_key_exists('ids', $attr)) return '';
+
     /* We recover posts info but... not in the same order as the one given in parameters ($attr['ids'])*/
     $posts = get_posts(array('include' => $attr['ids'],'post_type' => 'attachment'));
 
@@ -52,6 +56,7 @@ function epfl_gallery_block($attr) {
 
     $output .= '<div class="gallery-nav mb-3" data-gallery="my-gallery-'.$instance.'" aria-hidden="true">';
 
+    
     /* We go through given image order */
     foreach($attr['ids'] as $post_id)
     {

--- a/frontend/epfl-gallery/view.php
+++ b/frontend/epfl-gallery/view.php
@@ -16,7 +16,7 @@ function epfl_gallery_block($attr) {
 
     $output = '';
     $instance=md5(implode(',', $attr) . rand());
-    
+
     /* We recover posts info but... not in the same order as the one given in parameters ($attr['ids'])*/
     $posts = get_posts(array('include' => $attr['ids'],'post_type' => 'attachment'));
 

--- a/frontend/epfl-gallery/view.php
+++ b/frontend/epfl-gallery/view.php
@@ -9,13 +9,14 @@ namespace EPFL\Plugins\Gutenberg\Gallery;
 
 
 function epfl_gallery_block($attr) {
-    $output = '';
-    $instance=md5(implode(',', $attr) . rand());
-
-    /* For an unknown reason, this function can be called with $attr equal to an empty array... so there are
-        PHP Warnings in the logs because we are trying to access 'ids' key. */
+    
+    /* If a gallery block is added but never configured, this function will be called with $attr equal to an empty array... 
+        so there are PHP Warnings in the logs because we are trying to access 'ids' key. */
     if(!array_key_exists('ids', $attr)) return '';
 
+    $output = '';
+    $instance=md5(implode(',', $attr) . rand());
+    
     /* We recover posts info but... not in the same order as the one given in parameters ($attr['ids'])*/
     $posts = get_posts(array('include' => $attr['ids'],'post_type' => 'attachment'));
 

--- a/plugin.php
+++ b/plugin.php
@@ -3,7 +3,7 @@
  * Plugin Name: wp-gutenberg-epfl
  * Description: EPFL Gutenberg Blocks
  * Author: WordPress EPFL Team
- * Version: 1.7.8
+ * Version: 1.7.9
  */
 
 namespace EPFL\Plugins\Gutenberg;


### PR DESCRIPTION
La fonction de rendu peut être appelée avec un paramètre `$attr` qui est un tableau vide dans le cas où on mettrait un bloc `wp:gallery` vide sur une page. 
Donc ajout d'un check pour ne rien retourner si le tableau est vide, et éviter des Warnings dans les logs.