### PR TITLE
Delete duplicate members

### DIFF
--- a/frontend/epfl-people/templates/hierarchical-card.php
+++ b/frontend/epfl-people/templates/hierarchical-card.php
@@ -12,9 +12,10 @@ namespace EPFL\Plugins\Gutenberg\People;
         
         foreach($persons as $index => $element) {
 
-            sort_members($element->members);
+            $members = delete_duplicate_persons($element->members);
+            sort_members($members);
           
-            foreach($element->members as $index => $person) {
+            foreach($members as $index => $person) {
 
                 $photo_url = epfl_people_get_photo($person);
                 

--- a/frontend/epfl-people/templates/hierarchical-list.php
+++ b/frontend/epfl-people/templates/hierarchical-list.php
@@ -13,9 +13,10 @@
 
         foreach($persons as $index => $element) { 
             
-            sort_members($element->members);
+            $members = delete_duplicate_persons($element->members);
+            sort_members($members);
 
-            foreach($element->members as $index => $person) {
+            foreach($members as $index => $person) {
 
                 $photo_url  = epfl_people_get_photo($person);
                 $phones     = epfl_people_get_phones($person, HIERARCHICAL_ORDER);

--- a/frontend/epfl-people/templates/hierarchical-with-title-card.php
+++ b/frontend/epfl-people/templates/hierarchical-with-title-card.php
@@ -13,9 +13,10 @@ namespace EPFL\Plugins\Gutenberg\People;
                 $markup .= '<div class="card-deck">';
             }
 
-            sort_members($element->members);
+            $members = delete_duplicate_persons($element->members);
+            sort_members($members);
 
-            foreach($element->members as $index => $person) {
+            foreach($members as $index => $person) {
 
                 $photo_url = epfl_people_get_photo($person);
                 

--- a/frontend/epfl-people/templates/hierarchical-with-title-list.php
+++ b/frontend/epfl-people/templates/hierarchical-with-title-list.php
@@ -13,9 +13,10 @@
             $markup .= '<h4 class="my-3">' . $element->label . '</h4>';
             $markup .= '<div class="contact-list">';
 
-            sort_members($element->members);
+            $members = delete_duplicate_persons($element->members);
+            sort_members($members);
 
-            foreach($element->members as $index => $person) {
+            foreach($members as $index => $person) {
 
                 $photo_url  = epfl_people_get_photo($person);
                 $phones     = epfl_people_get_phones($person, HIERARCHICAL_ORDER);

--- a/frontend/epfl-people/utils.php
+++ b/frontend/epfl-people/utils.php
@@ -7,6 +7,24 @@ define(__NAMESPACE__ . "\HIERARCHICAL_ORDER_WITH_TITLE", "hierarchical-with-titl
 define(__NAMESPACE__ . "\ALPHABETICAL_ORDER", "alphabetical");
 
 /**
+ * Delete duplicate entry from array
+ */
+function delete_duplicate_persons($array) {
+  $temp_array = array();
+  $i = 0;
+  $key_array = array();
+
+  foreach($array as $val) {
+      if (!in_array($val->sciper, $key_array)) {
+          $key_array[$i] = $val->sciper;
+          $temp_array[$i] = $val;
+      }
+      $i++;
+  }
+  return $temp_array;
+}
+
+/**
  * Sort by name members of same function (Hierarchical order)
  */
 function sort_members(&$members)

--- a/plugin.php
+++ b/plugin.php
@@ -3,7 +3,7 @@
  * Plugin Name: wp-gutenberg-epfl
  * Description: EPFL Gutenberg Blocks
  * Author: WordPress EPFL Team
- * Version: 1.7.9
+ * Version: 1.7.10
  */
 
 namespace EPFL\Plugins\Gutenberg;


### PR DESCRIPTION
Lorsque l'utilisateur WP définit plusieurs unités dans le bloc people, si des personnes appartiennent à 2 ou plusieurs unités alors ces personnes seront affichées plusieurs fois.
Cette PR corrige ce problème

Testé ici : https://charte-wp.epfl.ch/gutenberg/1549-2/