### PR TITLE
Fix sections field empty

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -3,7 +3,7 @@
  * Plugin Name: wp-gutenberg-epfl
  * Description: EPFL Gutenberg Blocks
  * Author: WordPress EPFL Team
- * Version: 1.7.10
+ * Version: 1.7.11
  */
 
 namespace EPFL\Plugins\Gutenberg;

--- a/src/epfl-news/index.js
+++ b/src/epfl-news/index.js
@@ -13,7 +13,7 @@ registerBlockType(
 	'epfl/news',
 	{
 		title: __( "EPFL News", 'epfl'),
-		description: 'v1.1.1',
+		description: 'v1.1.2',
 		icon: newsIcon,
 		category: 'common',
 		keywords: [

--- a/src/epfl-news/inspector.js
+++ b/src/epfl-news/inspector.js
@@ -23,7 +23,7 @@ export default class InspectorControlsNews extends Component {
     constructor(props) {
         super(props);
         this.state = {
-            selectedChannelId: 1,
+            selectedChannelId: props.attributes.channel,
             channels: null,
             categories: null,
             themes: null,
@@ -54,9 +54,6 @@ export default class InspectorControlsNews extends Component {
             .catch( err => console.log(err))
 
         let channelId = this.props.attributes.channel;
-        if (channelId == null) {
-          channelId = 1;
-        }
         let entryPointsSections = `${apiRestUrl}channels/${channelId}/projects/?format=json&limit=10`;
         axios.get(entryPointsSections)
         .then( response => response.data )


### PR DESCRIPTION
Ticket INC0336746

> Le bloc EPFL News de Wordpress semble avoir des soucis à garder la Section (a.k.a Rubrique) en mémoire. Du moins, à chaque fois que j'édite cette page, la Section «Coronavirus» s'efface systématiquement, et affiche toutes les actualités du canal.
https://www.epfl.ch/campus/security-safety/en/health/coronavirus-covid19/ 

Comme dans `state` le channel était setté à 1 (au lieu de la valeur de `props`) alors la section était resetté dans la méthode `componentDidUpdate()` 