### PR TITLE
Google Forms 1.0.9

### DIFF
--- a/frontend/epfl-google-forms/controller.php
+++ b/frontend/epfl-google-forms/controller.php
@@ -64,18 +64,3 @@ function epfl_google_forms_block( $attributes ) {
     return $markup;
 }
 
-
-/*
-    Add tags needed by block when we copy/paste HTML content to add a Google Form.
-    If we don't add tags to allowed list, they will be cleaned with WP version >5.2.4
-*/
-function add_block_allowed_tags($tags)
-{
-    if(!array_key_exists('iframe', $tags)) $tags['iframe'] = [];
-    $tags['iframe']['src'] = true;
-    $tags['iframe']['width'] = true;
-    $tags['iframe']['height'] = true;
-
-    return $tags;
-}
-add_filter('wp_kses_allowed_html', __NAMESPACE__.'\add_block_allowed_tags');

--- a/frontend/epfl-google-forms/controller.php
+++ b/frontend/epfl-google-forms/controller.php
@@ -6,48 +6,25 @@ use \EPFL\Plugins\Gutenberg\Lib\Utils;
 
 require_once(dirname(__FILE__).'/view.php');
 
-/*
-    Extracts an attribute from givent HTML code.
-    $attribute  -> Attribute name to extract
-    $from_code  -> HTML code in which to look for attribute.
-*/
-function epfl_google_forms_get_attribute($attribute, $from_code)
-{
-    if(preg_match('/'.$attribute.'="(.*?)"/', $from_code, $matches)!==1)
-    {
-        return null;
-    }
-    return $matches[1];
-}
 
 function epfl_google_forms_block( $attributes ) {
 
     /*
-    data contains thing like (encoded):
-    <iframe src="https://docs.google.com/forms/d/e/1FAIpQLSeLZkqncWIvRbQvnn3K8yKUEn0Of8s-JTFZ3l94TWAIHnovJA/viewform?embedded=true" width="640" height="663" frameborder="0" marginheight="0" marginwidth="0">Chargement en cours...</iframe>
-
     NOTE:
     This block also allow to use others subdomains of Google (.google.com) like maps, calendar, etc...
     */
 
-    $data = isset( $attributes['data'] ) ? urldecode($attributes['data']) : '';
+    $url = Utils::get_sanitized_attribute( $attributes, 'url', null);
+    $height = Utils::get_sanitized_attribute( $attributes, 'height', null);
 
-    /* Extracting needed attributes */
-    $src = epfl_google_forms_get_attribute('src', $data);
-    $height = epfl_google_forms_get_attribute('height', $data);
-
-    /*
-    var_dump($src);
-    var_dump($height);
-    */
 
     /* Checking if all attributes are present */
-    if($src===null || $height===null)
+    if($url===null || $height===null)
     {
         return Utils::render_user_msg(__("Error extracting parameters", "epfl"));
     }
     /* Extract host name to check it */
-    $url_host = parse_url($src, PHP_URL_HOST);
+    $url_host = parse_url($url, PHP_URL_HOST);
     
     /* Check that iframe has a Google host as source */
     if(preg_match('/\.google\.com$/', $url_host) !== 1)
@@ -60,7 +37,7 @@ function epfl_google_forms_block( $attributes ) {
         return Utils::render_user_msg(__("Incorrect dimensions found", "epfl"));
     }
 
-    $markup = epfl_google_forms_render($src, $height);
+    $markup = epfl_google_forms_render($url, $height);
     return $markup;
 }
 

--- a/plugin.php
+++ b/plugin.php
@@ -3,7 +3,7 @@
  * Plugin Name: wp-gutenberg-epfl
  * Description: EPFL Gutenberg Blocks
  * Author: WordPress EPFL Team
- * Version: 1.7.11
+ * Version: 1.7.12
  */
 
 namespace EPFL\Plugins\Gutenberg;

--- a/src/epfl-google-forms/index.js
+++ b/src/epfl-google-forms/index.js
@@ -35,9 +35,6 @@ registerBlockType( 'epfl/google-forms', {
 		url: {
 			type: 'string',
 		},
-		width: {
-			type: 'integer',
-		},
 		height: {
 			type: 'integer',
 		}
@@ -74,21 +71,23 @@ registerBlockType( 'epfl/google-forms', {
 		// Parse HTML pasted code to extract necessary information
 		function parseData(dataToParse) {
 			
+			if(dataToParse == "")
+			{
+				setAttributes( { data: "" } )
+				return
+			}
 			// Extracting informations
 			let parsedUrl = extactInfos(dataToParse, /src="(.*?)"/)
 			let parsedHeight = extactInfos(dataToParse, /height="(.*?)"/)
-			let parsedWidth = extactInfos(dataToParse, /width="(.*?)"/)
 
 			// One of the information cannot be found
-			if(parsedUrl !== false  || parsedHeight !== false || parsedWidth !== false) 
+			if(parsedUrl !== false  || parsedHeight !== false ) 
 			{
 				// Updating attributes.
 				setAttributes( { url: parsedUrl } )
 				parsedHeight = Number(parsedHeight)
 				setAttributes( { height: parsedHeight } )
-				parsedWidth = Number(parsedWidth)
-				setAttributes( { width: parsedWidth } )
-
+				
 				// Display confirmation
 				openConfirmationModal()
 
@@ -123,11 +122,6 @@ registerBlockType( 'epfl/google-forms', {
 							label={ __('URL', 'epfl') }
                             value={ attributes.url }
                             onChange={ url => setAttributes( { url } ) }
-                        />
-						<TextControl
-							label={ __('Width', 'epfl') }
-                            value={ attributes.width }
-                            onChange={ width => setAttributes( { width } ) }
                         />
 						<TextControl
 							label={ __('Height', 'epfl') }

--- a/src/epfl-google-forms/index.js
+++ b/src/epfl-google-forms/index.js
@@ -12,26 +12,68 @@ const {
 } = wp.editor;
 
 const {
-    TextareaControl,
+	TextareaControl,
+	TextControl,
 } = wp.components;
 
 const { Fragment } = wp.element;
 
 registerBlockType( 'epfl/google-forms', {
 	title: __( 'Google Forms', 'epfl'),
-	description: 'v1.0.8',
+	description: 'v1.0.9',
 	icon: googleFormsIcon,
 	category: 'common',
 	attributes: {
         data: {
 			type: 'string',
-        },
+		},
+		url: {
+			type: 'url',
+		},
+		width: {
+			type: 'integer',
+		},
+		height: {
+			type: 'integer',
+		}
 	},
 	supports : {
 		customClassName: false, // Removes the default field in the inspector that allows you to assign a custom class
 	},
 	edit: ( props ) => {
-        const { attributes, className, setAttributes } = props
+		const { attributes, className, setAttributes } = props
+		
+		function extactInfos(fromData, regex)
+		{
+			let infos = fromData.match(regex)
+
+			if(Array.isArray(infos))
+			{
+				return infos[1]
+			}
+			return false
+		}
+
+		function parseData(dataToParse) {
+			
+			// Extracting informations
+			let parsedUrl = extactInfos(dataToParse, /src="(.*?)"/)
+			let parsedHeight = extactInfos(dataToParse, /height="(.*?)"/)
+			let parsedWidth = extactInfos(dataToParse, /width="(.*?)"/)
+
+			// One of the information cannot be found
+			if(parsedUrl !== false  || parsedHeight !== false || parsedWidth !== false) 
+			{
+				setAttributes( { url: parsedUrl } )
+				parsedHeight = Number(parsedHeight)
+				setAttributes( { height: parsedHeight } )
+				parsedWidth = Number(parsedWidth)
+				setAttributes( { width: parsedWidth } )
+			}
+			
+			setAttributes( { data: "" } )
+			
+        }
 
         return (
             <Fragment>
@@ -41,10 +83,26 @@ registerBlockType( 'epfl/google-forms', {
                 <div className={ className }>
                     <h2>{ __('EPFL Google Forms', 'epfl') }</h2>
                         <TextareaControl
-							label={ __('Google Forms <iframe> HTML code', 'epfl')}
-                            value={ attributes.data }
-                            onChange={ data => setAttributes( { data } ) }
-                            help={ __('Paste here the <iframe> HTML code you find in "< >" tab when you press the "Send" button on a GoogleForm edition page', 'epfl') }
+							value={ attributes.data }
+							onChange={ parseData }
+							rows = { '2' }
+                            placeholder={ __('Paste here the <iframe> HTML code you find in "< >" tab when you press the "Send" button on a GoogleForm edition page, it will extract needed parameters', 'epfl') }
+                        />
+					<h4>{ __('Configuration', 'epfl') }</h4>
+                        <TextControl
+							label={ __('URL', 'epfl') }
+                            value={ attributes.url }
+                            onChange={ url => setAttributes( { url } ) }
+                        />
+						<TextControl
+							label={ __('Width', 'epfl') }
+                            value={ attributes.width }
+                            onChange={ width => setAttributes( { width } ) }
+                        />
+						<TextControl
+							label={ __('Height', 'epfl') }
+                            value={ attributes.height }
+                            onChange={ height => setAttributes( { height } ) }
                         />
                 </div>
             </Fragment>

--- a/src/epfl-google-forms/index.js
+++ b/src/epfl-google-forms/index.js
@@ -14,9 +14,14 @@ const {
 const {
 	TextareaControl,
 	TextControl,
+	Modal,
+	Button
 } = wp.components;
 
-const { Fragment } = wp.element;
+const { 
+	Fragment,
+	useState,
+} = wp.element;
 
 registerBlockType( 'epfl/google-forms', {
 	title: __( 'Google Forms', 'epfl'),
@@ -28,7 +33,7 @@ registerBlockType( 'epfl/google-forms', {
 			type: 'string',
 		},
 		url: {
-			type: 'url',
+			type: 'string',
 		},
 		width: {
 			type: 'integer',
@@ -43,11 +48,21 @@ registerBlockType( 'epfl/google-forms', {
 	edit: ( props ) => {
 		const { attributes, className, setAttributes } = props
 		
+		// information modal window
+		const [ isConfirmationOpen, setConfirmationOpen ] = useState( false );
+		const openConfirmationModal = () => setConfirmationOpen( true );
+		const closeConfirmationModal = () => setConfirmationOpen( false );
+
+		// Error modal window
+		const [ isErrorOpen, setErrorOpen ] = useState( false );
+		const openErrorModal = () => setErrorOpen( true );
+		const closeErrorModal = () => setErrorOpen( false );
+		
 		function extactInfos(fromData, regex)
 		{
 			let infos = fromData.match(regex)
 
-			if(Array.isArray(infos))
+			if(Array.isArray(infos) && infos.length > 1)
 			{
 				return infos[1]
 			}
@@ -69,9 +84,16 @@ registerBlockType( 'epfl/google-forms', {
 				setAttributes( { height: parsedHeight } )
 				parsedWidth = Number(parsedWidth)
 				setAttributes( { width: parsedWidth } )
+
+				openConfirmationModal()
+
+				setAttributes( { data: "" } )
 			}
-			
-			setAttributes( { data: "" } )
+			else // There was at least one error
+			{
+				openErrorModal()
+				setAttributes( { data: dataToParse } )
+			}
 			
         }
 
@@ -104,6 +126,26 @@ registerBlockType( 'epfl/google-forms', {
                             value={ attributes.height }
                             onChange={ height => setAttributes( { height } ) }
                         />
+						{ isConfirmationOpen && (
+						<Modal
+							title={ __('Information extracted', 'epfl') }
+							onRequestClose={ closeConfirmationModal }>
+							<p>{ __('Information have been extracted from pasted HTML code', 'epfl') }</p>
+							<Button isDefault onClick={ closeConfirmationModal }>
+								{ __('Close', 'epfl') }
+							</Button>
+						</Modal>
+						) }		
+						{ isErrorOpen && (
+						<Modal
+							title={ __('Error extracting information', 'epfl') }
+							onRequestClose={ closeErrorModal }>
+							<p><font color="#F00">{ __('Wrong HTML code given, impossible to extract information.', 'epfl') }</font></p>
+							<Button isDefault onClick={ closeErrorModal }>
+								{ __('Close', 'epfl') }
+							</Button>
+						</Modal>
+						) }				
                 </div>
             </Fragment>
 		)

--- a/src/epfl-google-forms/index.js
+++ b/src/epfl-google-forms/index.js
@@ -57,7 +57,7 @@ registerBlockType( 'epfl/google-forms', {
 		
 
 		// extract information from HTML pasted code
-		function extactInfos(fromData, regex)
+		function extractInfos(fromData, regex)
 		{
 			let infos = fromData.match(regex)
 
@@ -77,8 +77,8 @@ registerBlockType( 'epfl/google-forms', {
 				return
 			}
 			// Extracting informations
-			let parsedUrl = extactInfos(dataToParse, /src="(.*?)"/)
-			let parsedHeight = extactInfos(dataToParse, /height="(.*?)"/)
+			let parsedUrl = extractInfos(dataToParse, /src="(.*?)"/)
+			let parsedHeight = extractInfos(dataToParse, /height="(.*?)"/)
 
 			// One of the information cannot be found
 			if(parsedUrl !== false  || parsedHeight !== false ) 

--- a/src/epfl-google-forms/index.js
+++ b/src/epfl-google-forms/index.js
@@ -58,6 +58,8 @@ registerBlockType( 'epfl/google-forms', {
 		const openErrorModal = () => setErrorOpen( true );
 		const closeErrorModal = () => setErrorOpen( false );
 		
+
+		// extract information from HTML pasted code
 		function extactInfos(fromData, regex)
 		{
 			let infos = fromData.match(regex)
@@ -69,6 +71,7 @@ registerBlockType( 'epfl/google-forms', {
 			return false
 		}
 
+		// Parse HTML pasted code to extract necessary information
 		function parseData(dataToParse) {
 			
 			// Extracting informations
@@ -79,19 +82,24 @@ registerBlockType( 'epfl/google-forms', {
 			// One of the information cannot be found
 			if(parsedUrl !== false  || parsedHeight !== false || parsedWidth !== false) 
 			{
+				// Updating attributes.
 				setAttributes( { url: parsedUrl } )
 				parsedHeight = Number(parsedHeight)
 				setAttributes( { height: parsedHeight } )
 				parsedWidth = Number(parsedWidth)
 				setAttributes( { width: parsedWidth } )
 
+				// Display confirmation
 				openConfirmationModal()
 
+				// We set text area as empty
 				setAttributes( { data: "" } )
 			}
 			else // There was at least one error
 			{
+				// Displaying error box
 				openErrorModal()
+				// keeping pasted value in cell
 				setAttributes( { data: dataToParse } )
 			}
 			


### PR DESCRIPTION
Pour fonctionner, le plugin autoriser les éléments `iframe` (afin de pouvoir enregistrer le code copié-collé par l'utilisateur) mais du coup, ça entrait en conflit avec le plugin "EPFL Content Filter".
- Suppression de l'autorisation de la balise `iframe `
- Ajout de champs supplémentaires au bloc "Google Forms" pour mettre l'URL et la hauteur.
- Changement de la manière de fonctionner pour faire en sorte que lorsque l'on fait un "coller" de code HTML dans la zone de texte supérieure, un parsing s'effectue automatiquement pour extraire les 2 informations (URL et hauteur). Si tout est OK, un message de confirmation est affiché
- En cas d'erreur de parsing des informations, un message d'erreur est affiché 💥 
- Mise à jour du render pour ne plus extraire les infos depuis le code HTML copié-collé.
