### PR TITLE
Set faq inside a grid class container

### DIFF
--- a/frontend/epfl-faq/controller.php
+++ b/frontend/epfl-faq/controller.php
@@ -48,7 +48,7 @@ function epfl_faq_block($data, $inner_content) {
 
 ?>
 
-<div class="container py-3">
+<div class="grid py-3">
   <ul class="link-list epfl-faq-header">
   </ul>
   <?php

--- a/frontend/epfl-faq/controller.php
+++ b/frontend/epfl-faq/controller.php
@@ -33,7 +33,7 @@ function epfl_faq_item_block($attributes, $inner_content)
 
 /**
  * Render a FAQ block
- * 
+ *
  * A FAQ block includes epfl/faq-item blocks (one for each couple "question/answer") and displays an index with links to each questions
  * before the first question/answer is displayed.
  * This link list is generated using jQuery on client side. Code which do this is in "js/faq-header.js". This means we have to add some
@@ -48,10 +48,10 @@ function epfl_faq_block($data, $inner_content) {
 
 ?>
 
-<div class="container-grid py-3">
+<div class="container py-3">
   <ul class="link-list epfl-faq-header">
   </ul>
-  <?php 
+  <?php
      echo $inner_content;
   ?>
 </div>

--- a/plugin.php
+++ b/plugin.php
@@ -3,7 +3,7 @@
  * Plugin Name: wp-gutenberg-epfl
  * Description: EPFL Gutenberg Blocks
  * Author: WordPress EPFL Team
- * Version: 1.9.1
+ * Version: 1.9.2
  */
 
 namespace EPFL\Plugins\Gutenberg;


### PR DESCRIPTION
Fix https://epfl-webvolution.atlassian.net/browse/WEBEVOL-68

Sur le modèle d'epfl_video (https://github.com/epfl-si/wp-gutenberg-epfl/blob/9038d6c62741dc8b0e64511a5f36b3b0f8a93357/frontend/epfl-video/view.php#L14), et malgré que cette classe "grid" n'est pas définie, je passe la classe d'epfl_FAQ à "grid", 