### PR TITLE
Memento: Filter past events by year

### DIFF
--- a/frontend/epfl-memento/controller.php
+++ b/frontend/epfl-memento/controller.php
@@ -117,12 +117,18 @@ function epfl_memento_block( $attributes ) {
     $category   = Utils::get_sanitized_attribute( $attributes, 'category', 0 );
     $keyword    = Utils::get_sanitized_attribute( $attributes, 'keyword' );
     $period     = Utils::get_sanitized_attribute( $attributes, 'period' );
+    $year       = Utils::get_sanitized_attribute( $attributes, 'year' );
 
-    /*
+    
     var_dump("Memento Id: " . $memento_id);
     var_dump("Lang: " . $lang);
     var_dump("Template: " . $template);
-    */
+    var_dump("nb_events: " . $nb_events);
+    var_dump("category: " . $category);
+    var_dump("keyword: " . $keyword);
+    var_dump("period: " . $period);
+    var_dump("year: " . $year);
+    
 
     if (epfl_memento_check_required_parameters($memento_id, $lang) == FALSE) {
         return Utils::render_user_msg("Memento shortcode: Please check required parameters");
@@ -137,6 +143,7 @@ function epfl_memento_block( $attributes ) {
         $keyword,
         $period
     );
+    var_dump($url);
     $events = Utils::get_items($url);
     $memento_slug = get_memento_slug($memento_id);
     $markup = epfl_memento_render($events->results, $template, $memento_slug);

--- a/frontend/epfl-memento/controller.php
+++ b/frontend/epfl-memento/controller.php
@@ -3,7 +3,7 @@
 /**
  * Plugin Name: EPFL Memento shortcode
  * Description: provides a shortcode to display events feed
- * @version: 1.1
+ * @version: 1.2
  * @copyright: Copyright (c) 2017 Ecole Polytechnique Federale de Lausanne, Switzerland
  *
  * Text Domain: epfl-memento
@@ -44,7 +44,7 @@ function get_memento_slug($memento_id) {
  * @param $period: period to filter past event or upcoming events
  * @return the API URL of the memento
  */
-function epfl_memento_build_api_url($memento_id, $lang, $template, $nb_events, $category, $keyword, $period)
+function epfl_memento_build_api_url($memento_id, $lang, $template, $nb_events, $category, $keyword, $period, $year)
 {
     // call REST API to get the number of mementos
     $memento_response = Utils::get_items(MEMENTO_API_URL);
@@ -77,6 +77,10 @@ function epfl_memento_build_api_url($memento_id, $lang, $template, $nb_events, $
     // period
     if ($period === 'past' or $period === 'upcoming') {
         $url .= '&period=' . $period;
+    }
+
+    if ($period === 'past' and $year !== '') {
+        $url .= '&start_year=' . $year;
     }
 
     return $url;
@@ -119,7 +123,7 @@ function epfl_memento_block( $attributes ) {
     $period     = Utils::get_sanitized_attribute( $attributes, 'period' );
     $year       = Utils::get_sanitized_attribute( $attributes, 'year' );
 
-    
+    /*
     var_dump("Memento Id: " . $memento_id);
     var_dump("Lang: " . $lang);
     var_dump("Template: " . $template);
@@ -128,7 +132,7 @@ function epfl_memento_block( $attributes ) {
     var_dump("keyword: " . $keyword);
     var_dump("period: " . $period);
     var_dump("year: " . $year);
-    
+    */
 
     if (epfl_memento_check_required_parameters($memento_id, $lang) == FALSE) {
         return Utils::render_user_msg("Memento shortcode: Please check required parameters");
@@ -141,9 +145,10 @@ function epfl_memento_block( $attributes ) {
         $nb_events,
         $category,
         $keyword,
-        $period
+        $period,
+        $year
     );
-    var_dump($url);
+    
     $events = Utils::get_items($url);
     $memento_slug = get_memento_slug($memento_id);
     $markup = epfl_memento_render($events->results, $template, $memento_slug);

--- a/frontend/epfl-memento/controller.php
+++ b/frontend/epfl-memento/controller.php
@@ -148,10 +148,10 @@ function epfl_memento_block( $attributes ) {
         $period,
         $year
     );
-    
+
     $events = Utils::get_items($url);
     $memento_slug = get_memento_slug($memento_id);
-    $markup = epfl_memento_render($events->results, $template, $memento_slug);
+    $markup = epfl_memento_render($events->results, $template, $memento_slug, $period);
     return $markup;
 }
 

--- a/frontend/epfl-memento/templates/listing_with_the_first_highlighted_event.php
+++ b/frontend/epfl-memento/templates/listing_with_the_first_highlighted_event.php
@@ -1,7 +1,7 @@
 <?php
     namespace EPFL\Plugins\Gutenberg\Memento;
 
-    function epfl_memento_listing_with_the_first_highlighted_event($results, $memento_name) {
+    function epfl_memento_listing_with_the_first_highlighted_event($results, $memento_name, $period) {
 
         $memento_url = "https://memento.epfl.ch/" . $memento_name;
         $display_first_event = TRUE;
@@ -10,7 +10,11 @@
         $markup = '<div class="container my-3">';
         $markup .= '<div class="row align-items-center">';
         $markup .= '<div class="col-md-6">';
-        $markup .= '<h2>' . __('Next events', 'epfl') . '</h2>';
+        if ($period === 'past') { 
+          $markup .= '<h2>' . __('Past events', 'epfl') . '</h2>';
+        } else {
+          $markup .= '<h2>' . __('Next events', 'epfl') . '</h2>';
+        }
         $markup .= '</div>';
         $markup .= '<div class="col-md-6 text-right">';
         $markup .= '<a href="' . esc_url($memento_url) . '">' . __('See all events', 'epfl') . '</a>';

--- a/frontend/epfl-memento/view.php
+++ b/frontend/epfl-memento/view.php
@@ -6,19 +6,19 @@
     require_once(dirname(__FILE__) . '/templates/listing_with_the_first_highlighted_event.php');
     require_once(dirname(__FILE__) . '/templates/listing_without_the_first_highlighted_event.php');
 
-    function epfl_memento_render($results, $template, $memento_name) {
+    function epfl_memento_render($results, $template, $memento_name, $period) {
 
         $function_to_be_called = __NAMESPACE__ . '\epfl_memento_' . $template;
-        $markup = $function_to_be_called($results, $memento_name);
+        $markup = $function_to_be_called($results, $memento_name, $period);
 
         return $markup;
     }
 
-    function epfl_memento_slider_with_the_first_highlighted_event($results, $memento_name) {
-        return epfl_memento_slider($results, "1", $memento_name);
+    function epfl_memento_slider_with_the_first_highlighted_event($results, $memento_name, $period) {
+        return epfl_memento_slider($results, "1", $memento_name, $period);
     }
 
-    function epfl_memento_slider_without_the_first_highlighted_event($results, $memento_name) {
+    function epfl_memento_slider_without_the_first_highlighted_event($results, $memento_name, $period) {
         return epfl_memento_slider($results, "2", $memento_name);
     }
 ?>

--- a/plugin.php
+++ b/plugin.php
@@ -3,7 +3,7 @@
  * Plugin Name: wp-gutenberg-epfl
  * Description: EPFL Gutenberg Blocks
  * Author: WordPress EPFL Team
- * Version: 1.11.0
+ * Version: 1.12.0
  */
 
 namespace EPFL\Plugins\Gutenberg;
@@ -23,7 +23,7 @@ function epfl_gutenberg_load_textdomain() {
 	load_plugin_textdomain( 'epfl', FALSE, basename( dirname( __FILE__ ) ) . '/languages/' );
 }
 add_action( 'plugins_loaded',  __NAMESPACE__ . '\epfl_gutenberg_load_textdomain' );
-/*
+
 # allow to fetch rest api with the lang parameter
 function polylang_json_api_init() {
     global $polylang;
@@ -47,7 +47,7 @@ function polylang_json_api_languages() {
 
 // fix polylang language segmentation
 add_action( 'rest_api_init' , __NAMESPACE__ . '\polylang_json_api_init' );
-*/
+
 /**
  * Only allow blocks starting with "epfl/" in editor. If others blocks have to be allowed too, comoing from WordPress
  * or others plugins, you'll have to add another filter to add them, for example in a MU-Plugin. But be careful to

--- a/plugin.php
+++ b/plugin.php
@@ -23,7 +23,7 @@ function epfl_gutenberg_load_textdomain() {
 	load_plugin_textdomain( 'epfl', FALSE, basename( dirname( __FILE__ ) ) . '/languages/' );
 }
 add_action( 'plugins_loaded',  __NAMESPACE__ . '\epfl_gutenberg_load_textdomain' );
-
+/*
 # allow to fetch rest api with the lang parameter
 function polylang_json_api_init() {
     global $polylang;
@@ -47,7 +47,7 @@ function polylang_json_api_languages() {
 
 // fix polylang language segmentation
 add_action( 'rest_api_init' , __NAMESPACE__ . '\polylang_json_api_init' );
-
+*/
 /**
  * Only allow blocks starting with "epfl/" in editor. If others blocks have to be allowed too, comoing from WordPress
  * or others plugins, you'll have to add another filter to add them, for example in a MU-Plugin. But be careful to

--- a/src/epfl-memento/index.js
+++ b/src/epfl-memento/index.js
@@ -14,7 +14,7 @@ registerBlockType(
 	'epfl/memento',
 	{
 		title: __('EPFL Memento', 'epfl'),
-		description: 'v1.0.7',
+		description: 'v1.1.0',
 		icon: mementoIcon,
 		category: 'common',
 		keywords: [

--- a/src/epfl-memento/index.js
+++ b/src/epfl-memento/index.js
@@ -44,7 +44,11 @@ registerBlockType(
 			period: {
 				type: 'string',
 				default: 'upcoming',
-			},
+      },
+      year: {
+        type: 'string',
+        default: 'no-filter',
+      },
 			keyword: {
 				type: 'string',
 				default: "",

--- a/src/epfl-memento/inspector.js
+++ b/src/epfl-memento/inspector.js
@@ -147,7 +147,6 @@ export default class InspectorControlsMemento extends Component {
                     </PanelBody>
                     <PanelBody title={ __('Period', 'epfl') }>
                         <RadioControl
-                            style={ {"marginBottom": 0} }
                             label={ __("Select a period", 'epfl') }
                             help={ __("Do you want upcoming events or past events ?", 'epfl') }
                             selected={ attributes.period }

--- a/src/epfl-memento/inspector.js
+++ b/src/epfl-memento/inspector.js
@@ -81,6 +81,34 @@ export default class InspectorControlsMemento extends Component {
                 optionsCategoriesList.push({ label: category.en_label, value: category.id });
             });
 
+            let optionsYearsList = [
+              { value: 'no-filter', label: __('No Filter', 'epfl') },
+              { value: '2020', label: '2020' },
+              { value: '2019', label: '2019' },
+              { value: '2018', label: '2018' },
+              { value: '2017', label: '2017' },
+              { value: '2016', label: '2016' },
+              { value: '2015', label: '2015' },
+              { value: '2014', label: '2014' },
+              { value: '2013', label: '2013' },
+              { value: '2012', label: '2012' },
+              { value: '2011', label: '2011' },
+              { value: '2010', label: '2010' },
+            ]
+            
+            let filterPastEventsByYear;
+            if (!!attributes.period && attributes.period === 'past') {
+                filterPastEventsByYear = (
+                    <SelectControl
+                        label={ __("Filter events by year", 'epfl') }
+                        help={ __("Do you want filter past events by year? Please select a year.", 'epfl') }
+                        value={ attributes.year }
+                        options={ optionsYearsList }
+                        onChange={ year => setAttributes( { year } ) }
+                    />
+                )
+            }
+
             content = (
                 <InspectorControls>
                     <p><a className="wp-block-help" href={ __('https://www.epfl.ch/campus/services/memento-en/', 'epfl') } target="new">{ __('Online help', 'epfl') } </a></p>
@@ -125,12 +153,14 @@ export default class InspectorControlsMemento extends Component {
                     </PanelBody>
                     <PanelBody title={ __('Period', 'epfl') }>
                         <RadioControl
+                            style={ {"marginBottom": 0} }
                             label={ __("Select a period", 'epfl') }
                             help={ __("Do you want upcoming events or past events ?", 'epfl') }
                             selected={ attributes.period }
                             options={ optionsPeriodsList }
                             onChange={ period => setAttributes( { period } ) }
-	                    />
+	                      />
+                        { filterPastEventsByYear }
                     </PanelBody>
                     <PanelBody title={ __( 'Category', 'epfl' ) }>
                         <SelectControl

--- a/src/epfl-memento/inspector.js
+++ b/src/epfl-memento/inspector.js
@@ -83,19 +83,13 @@ export default class InspectorControlsMemento extends Component {
 
             let optionsYearsList = [
               { value: 'no-filter', label: __('No Filter', 'epfl') },
-              { value: '2020', label: '2020' },
-              { value: '2019', label: '2019' },
-              { value: '2018', label: '2018' },
-              { value: '2017', label: '2017' },
-              { value: '2016', label: '2016' },
-              { value: '2015', label: '2015' },
-              { value: '2014', label: '2014' },
-              { value: '2013', label: '2013' },
-              { value: '2012', label: '2012' },
-              { value: '2011', label: '2011' },
-              { value: '2010', label: '2010' },
             ]
             
+            const currentYear = new Date().getFullYear();
+            for(let year = currentYear; year >= 2008 ; year--) {
+              optionsYearsList.push({ label: year, value: year });
+            }
+
             let filterPastEventsByYear;
             if (!!attributes.period && attributes.period === 'past') {
                 filterPastEventsByYear = (

--- a/src/epfl-memento/preview.js
+++ b/src/epfl-memento/preview.js
@@ -34,7 +34,7 @@ export default class PreviewMemento extends Component {
 			eventsUrl += `&keywords=${attributes.keyword}`;
     }
     
-    if (attributes.period === 'past' && attributes.year) {
+    if (attributes.period === 'past' && attributes.year !== 'no-filter') {
       eventsUrl += `&start_year=${attributes.year}`;
     }
 

--- a/src/epfl-memento/preview.js
+++ b/src/epfl-memento/preview.js
@@ -18,7 +18,13 @@ export default class PreviewMemento extends Component {
 		const { attributes } = this.props;
 
 		let eventsUrl = `${BASE_MEMENTO_API_REST_URL}mementos/${attributes.memento}/events/`;
-		eventsUrl += `?format=json&lang=${attributes.lang}&period=${attributes.period}&limit=${attributes.nbEvents}`;
+    eventsUrl += `?format=json&period=${attributes.period}&limit=${attributes.nbEvents}`;
+
+    if (attributes.lang === 'fr') {
+      eventsUrl += `&lang=fr,en`;
+    } else {
+      eventsUrl += `&lang=en,fr`;
+    }
 
 		if (attributes.category !== 0) {
 			eventsUrl += `&category=${attributes.category}`;

--- a/src/epfl-memento/preview.js
+++ b/src/epfl-memento/preview.js
@@ -26,7 +26,11 @@ export default class PreviewMemento extends Component {
 
 		if (attributes.keyword !== '') {
 			eventsUrl += `&keywords=${attributes.keyword}`;
-		}
+    }
+    
+    if (attributes.period === 'past' && attributes.year) {
+      eventsUrl += `&start_year=${attributes.year}`;
+    }
 
 		return eventsUrl;
 	}

--- a/src/epfl-memento/utils.js
+++ b/src/epfl-memento/utils.js
@@ -1,4 +1,4 @@
-const prod = true;
+const prod = false;
 if (prod) {
   global.BASE_MEMENTO_API_REST_URL = "https://memento.epfl.ch/api/v1/";
 } else {

--- a/src/epfl-memento/utils.js
+++ b/src/epfl-memento/utils.js
@@ -1,4 +1,4 @@
-const prod = false;
+const prod = true;
 if (prod) {
   global.BASE_MEMENTO_API_REST_URL = "https://memento.epfl.ch/api/v1/";
 } else {


### PR DESCRIPTION
Filtrer les événements passés par année.

1. Les années vont de 2008 à 2020 car 2008 est la 1ère année pour laquelle on a des events.
2. L'année courante est définie dynamiquement, on aura évidement pas besoin de la changer chaque année
3. Pour certains templates, on avait le titre "Événements à venir". Ce titre évolue maintenant en fonction de l'attribut period soit passé soit futur. 
4. Corrige un bug côté Front End dans la gestion des langues. Pour que le flux d'événements soient identiques côté Front et côté Back End.

On peut tester cette PR : https://charte-wp.epfl.ch/gutenberg/filtrer-les-evenements-passes-par-annee/


