### PR TITLE
Order memento by name

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -3,7 +3,7 @@
  * Plugin Name: wp-gutenberg-epfl
  * Description: EPFL Gutenberg Blocks
  * Author: WordPress EPFL Team
- * Version: 1.15.0
+ * Version: 1.15.1
  */
 
 namespace EPFL\Plugins\Gutenberg;

--- a/src/epfl-memento/index.js
+++ b/src/epfl-memento/index.js
@@ -14,7 +14,7 @@ registerBlockType(
 	'epfl/memento',
 	{
 		title: __('EPFL Memento', 'epfl'),
-		description: 'v1.1.0',
+		description: 'v1.1.1',
 		icon: mementoIcon,
 		category: 'common',
 		keywords: [

--- a/src/epfl-memento/inspector.js
+++ b/src/epfl-memento/inspector.js
@@ -29,7 +29,7 @@ export default class InspectorControlsMemento extends Component {
     componentDidMount() {
         let apiRestUrl = BASE_MEMENTO_API_REST_URL;
 
-        let entryPointMementos = `${apiRestUrl}mementos/?format=json&limit=800`;
+        let entryPointMementos = `${apiRestUrl}mementos/?format=json&limit=800&ordering=en_name`;
 		axios.get(entryPointMementos)
 			.then( response => response.data.results )
 			.then( mementos => this.setState({ mementos }) )


### PR DESCRIPTION
Dans le bloc memento, il existe une liste déroulante des mémentos. 
Les noms de ces mementos ne sont pas dans l'ordre alphabétique.
Cette PR corrige cela.
Pour tester : https://charte-wp.epfl.ch/gutenberg/wp-admin/post.php?post=1630&action=edit