### PR TITLE
Bugfix: display issue on page/post highlight

### DIFF
--- a/frontend/epfl-page-highlight/controller.php
+++ b/frontend/epfl-page-highlight/controller.php
@@ -30,7 +30,7 @@ function epfl_page_highlight_block( $attributes ) {
 ?>
 
 <div class="container-full my-3">
-    <div class="fullwidth-teaser ' . $classes . '">
+    <div class="fullwidth-teaser <?php echo $classes; ?>">
 
 <?php if (has_post_thumbnail( $page )) { ?>
         <picture>

--- a/frontend/epfl-post-highlight/controller.php
+++ b/frontend/epfl-post-highlight/controller.php
@@ -11,7 +11,7 @@ use function EPFL\Plugins\Gutenberg\Lib\Templates\epfl_excerpt;
 
 function epfl_post_highlight_block( $attributes ) {
 
-    $layout = Utils::get_sanitized_attribute( $attributes, 'layout' );
+    $layout = Utils::get_sanitized_attribute( $attributes, 'layout', 'right' );
     $post   = Utils::get_sanitized_attribute( $attributes, 'post' );
     $post   = json_decode($post, true);
 
@@ -28,13 +28,13 @@ function epfl_post_highlight_block( $attributes ) {
     ob_start();
 ?>    
 <div class="container-full my-3">
-    <div class="fullwidth-teaser '<?php echo $classes ?>">
+    <div class="fullwidth-teaser <?php echo $classes; ?>">
 
 <?php if (has_post_thumbnail( $post )) { ?>
         <picture>
             <source media="(min-width: 1140px)" srcset="<?php echo get_the_post_thumbnail_url( $post, 'large' ) ?>">
                 <img src="<?php echo get_the_post_thumbnail_url( $post ); ?>" aria-labelledby="background-label" alt="" />
-        </picture> ';
+        </picture>
 <?php } ?>
 
         <div class="fullwidth-teaser-text">

--- a/frontend/epfl-post-highlight/controller.php
+++ b/frontend/epfl-post-highlight/controller.php
@@ -11,7 +11,7 @@ use function EPFL\Plugins\Gutenberg\Lib\Templates\epfl_excerpt;
 
 function epfl_post_highlight_block( $attributes ) {
 
-    $layout = Utils::get_sanitized_attribute( $attributes, 'layout', 'right' );
+    $layout = Utils::get_sanitized_attribute( $attributes, 'layout' );
     $post   = Utils::get_sanitized_attribute( $attributes, 'post' );
     $post   = json_decode($post, true);
 

--- a/plugin.php
+++ b/plugin.php
@@ -3,7 +3,7 @@
  * Plugin Name: wp-gutenberg-epfl
  * Description: EPFL Gutenberg Blocks
  * Author: WordPress EPFL Team
- * Version: 1.16.0
+ * Version: 1.16.1
  */
 
 namespace EPFL\Plugins\Gutenberg;

--- a/src/epfl-page-highlight/index.js
+++ b/src/epfl-page-highlight/index.js
@@ -8,7 +8,7 @@ registerBlockType(
 	'epfl/page-highlight',
 	{
 		title: __( "EPFL Page Highlight", 'epfl'),
-		description: 'v1.0.3',
+		description: 'v1.0.4',
 		category: 'common',
 		keywords: [
             __( 'page' , 'epfl'),

--- a/src/epfl-post-highlight/index.js
+++ b/src/epfl-post-highlight/index.js
@@ -8,7 +8,7 @@ registerBlockType(
 	'epfl/post-highlight',
 	{
 		title: __( "EPFL Post Highlight", 'epfl'),
-		description: 'v1.0.4',
+		description: 'v1.0.5',
 		category: 'common',
 		keywords: [
             __( 'post' , 'epfl'),


### PR DESCRIPTION
**post highlight**
- Il y avait un `';` qui trainait après reformatage du code...
- Mauvaise génération de HTML pour l'alignement du post

**page highlight**
- Mauvaise génération de HTML pour l'alignement de la page