### PR TITLE
Update memento link for past events

### DIFF
--- a/frontend/epfl-memento/templates/includes/card-slider-footer.inc.php
+++ b/frontend/epfl-memento/templates/includes/card-slider-footer.inc.php
@@ -11,6 +11,7 @@ $markup .= '            <svg class="icon" aria-hidden="true"><use xlink:href="#i
 $markup .= '        </button>';
 $markup .= '    </div>';
 $markup .= '</div>';
-$markup .= '<a href="' . esc_url("https://memento.epfl.ch/" . $memento_name . "/?period=30") . '">';
+
+$markup .= '<a href="' . esc_url(get_memento_url($period, $memento_name)) . '">';
 $markup .= __('Complete agenda of events', 'epfl');
 $markup .= '</a>';

--- a/frontend/epfl-memento/templates/listing_with_the_first_highlighted_event.php
+++ b/frontend/epfl-memento/templates/listing_with_the_first_highlighted_event.php
@@ -3,7 +3,7 @@
 
     function epfl_memento_listing_with_the_first_highlighted_event($results, $memento_name, $period) {
 
-        $memento_url = "https://memento.epfl.ch/" . $memento_name;
+        $memento_url = get_memento_url($period, $memento_name);
         $display_first_event = TRUE;
         $nb_events = count($results);
 

--- a/frontend/epfl-memento/templates/slider.php
+++ b/frontend/epfl-memento/templates/slider.php
@@ -2,7 +2,7 @@
     namespace EPFL\Plugins\Gutenberg\Memento;
 
     // template = 1
-    function epfl_memento_slider($results, $template, $memento_name) {
+    function epfl_memento_slider($results, $template, $memento_name, $period) {
 
         $memento_url = "https://memento.epfl.ch/" . $memento_name;
 

--- a/frontend/epfl-memento/utils.php
+++ b/frontend/epfl-memento/utils.php
@@ -88,3 +88,14 @@ function get_visual_url($event, $memento_name) {
     }
     return $visual_url;
 }
+
+function get_memento_url($period, $memento_name) {
+  if ($period === 'past') {
+    $now = date("Y-m-d");
+    $year = (intval(substr($now, 0, 4)) - 1) . substr($now, 4, 10) ;
+    $memento_url = "https://memento.epfl.ch/" . $memento_name . "/?period=365&date=" . $year;
+  } else {
+    $memento_url = "https://memento.epfl.ch/" . $memento_name;
+  }
+  return $memento_url;
+}

--- a/frontend/epfl-memento/view.php
+++ b/frontend/epfl-memento/view.php
@@ -19,6 +19,6 @@
     }
 
     function epfl_memento_slider_without_the_first_highlighted_event($results, $memento_name, $period) {
-        return epfl_memento_slider($results, "2", $memento_name);
+        return epfl_memento_slider($results, "2", $memento_name, $period);
     }
 ?>

--- a/plugin.php
+++ b/plugin.php
@@ -3,7 +3,7 @@
  * Plugin Name: wp-gutenberg-epfl
  * Description: EPFL Gutenberg Blocks
  * Author: WordPress EPFL Team
- * Version: 1.16.1
+ * Version: 1.16.2
  */
 
 namespace EPFL\Plugins\Gutenberg;


### PR DESCRIPTION
Le lien "Complete agenda of events" ne propose que les prochains events.
Si l'utilisateur a décidé d'afficher les events passés, ce lien doit devenir du genre :
https://memento.epfl.ch/epfl/?period=365&date=2019-06-03
Ainsi l'utilisateur pourra voir tous les events vieux d'un an max.

Pour tester : 
https://charte-wp.epfl.ch/gutenberg/memento-4/