### PR TITLE
EPFL-Courses: Use list for section filter instead of text entry

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -3,7 +3,7 @@
  * Plugin Name: wp-gutenberg-epfl
  * Description: EPFL Gutenberg Blocks
  * Author: WordPress EPFL Team
- * Version: 1.16.2
+ * Version: 1.17.0
  */
 
 namespace EPFL\Plugins\Gutenberg;

--- a/src/epfl-courses/index.js
+++ b/src/epfl-courses/index.js
@@ -10,7 +10,7 @@ registerBlockType(
 	'epfl/courses',
 	{
 		title: __( "EPFL Courses", 'epfl'),
-		description: 'v1.0.0',
+		description: 'v1.1.0',
 		icon: coursesIcon,
 		category: 'common',
 		keywords: [

--- a/src/epfl-courses/inspector.js
+++ b/src/epfl-courses/inspector.js
@@ -2,12 +2,12 @@ import React from 'react';
 
 const { __ } = wp.i18n
 const {
-  Component,
-  Fragment,
+    Component,
+    Fragment,
 } = wp.element
 
 const {
-	InspectorControls,
+    InspectorControls,
 } = wp.editor
 
 const {
@@ -23,78 +23,101 @@ export default class InspectorControlsCourses extends Component {
         const { attributes, setAttributes } = this.props
 
         let optionsTeachingLangList = [
-            { value: '', label: __('All', 'epfl')},
-            { value: 'fr', label: __('French', 'epfl')},
-            { value: 'en', label: __('English', 'epfl')},
+            { value: '', label: __('All', 'epfl') },
+            { value: 'fr', label: __('French', 'epfl') },
+            { value: 'en', label: __('English', 'epfl') },
         ];
 
         let optionsSemesterList = [
-            { value: '', label: __('All', 'epfl')},
-            { value: 'ete', label: __('Summer', 'epfl')},
-            { value: 'hiver', label: __('Winter', 'epfl')},
+            { value: '', label: __('All', 'epfl') },
+            { value: 'ete', label: __('Summer', 'epfl') },
+            { value: 'hiver', label: __('Winter', 'epfl') },
         ];
 
         let optionsOrientationList = [
-            { value: '', label: __('All', 'epfl')},
-            { value: 'MA', label: __('Master', 'epfl')},
-            { value: 'BA', label: __('Bachelor', 'epfl')},
+            { value: '', label: __('All', 'epfl') },
+            { value: 'MA', label: __('Master', 'epfl') },
+            { value: 'BA', label: __('Bachelor', 'epfl') },
+        ];
+
+        let optionsSectionList = [
+            { value: '', label: __('<none>', 'epfl') },
+            { value: 'AR', label: __('Architecture', 'epfl') },
+            { value: 'CGC', label: __('Chemistry and chemical engineering', 'epfl') },
+            { value: 'GC', label: __('Civil engineering', 'epfl') },
+            { value: 'SC', label: __('Communication systems', 'epfl') },
+            { value: 'IN', label: __('Computer science', 'epfl') },
+            { value: 'DH', label: __('Digital humanities', 'epfl') },
+            { value: 'EL', label: __('Electrical and electronic engineering', 'epfl') },
+            { value: 'IF', label: __('Financial engineering', 'epfl') },
+            { value: 'SIE', label: __('Environmental sciences and engineering', 'epfl') },
+            { value: 'SV', label: __('Life sciences engineering', 'epfl') },
+            { value: 'MTE', label: __('Management of technology', 'epfl') },
+            { value: 'MX', label: __('Materials science engineering', 'epfl') },
+            { value: 'MA', label: __('Mathematics', 'epfl') },
+            { value: 'GM', label: __('Mechanical engineering', 'epfl') },
+            { value: 'MT', label: __('Microengineering', 'epfl') },
+            { value: 'PH', label: __('Physics', 'epfl') },
+
+
         ];
 
         let content = "";
 
         content = (
             <InspectorControls>
-                <p><a className="wp-block-help" href={ __('https://www.epfl.ch/campus/services/courses-en/', 'epfl') } target="new">{ __('Online help', 'epfl') } </a></p>
-                <PanelBody title={ __( 'Select by', 'epfl') }>
+                <p><a className="wp-block-help" href={__('https://www.epfl.ch/campus/services/courses-en/', 'epfl')} target="new">{__('Online help', 'epfl')} </a></p>
+                <PanelBody title={__('Select by', 'epfl')}>
                     <TextControl
-                        label={__( 'Unit name', 'epfl')}
-                        value={ attributes.unit }
-                        help={ __('"GETALL" gives all courses in EPFL"', 'epfl') }
-						onChange={ unit => setAttributes( { unit } ) }
-					/>
-                    <h3>{__( 'OR', 'epfl')}</h3>
+                        label={__('Unit name', 'epfl')}
+                        value={attributes.unit}
+                        help={__('"GETALL" gives all courses in EPFL"', 'epfl')}
+                        onChange={unit => setAttributes({ unit })}
+                    />
+                    <h3>{__('OR', 'epfl')}</h3>
                     <TextControl
-                        label={__( 'Scipers', 'epfl')}
-                        value={ attributes.scipers }
-                        help={ __('You can enter many scipers separated by a comma', 'epfl') }
-						onChange={ scipers => setAttributes( { scipers } ) }
-					/>
-                    <h3>{__( 'OR', 'epfl')}</h3>
-                    <TextControl
-                        label={__( 'Section name', 'epfl')}
-                        value={ attributes.section }
-						onChange={ section => setAttributes( { section } ) }
-					/>
-                    
+                        label={__('Scipers', 'epfl')}
+                        value={attributes.scipers}
+                        help={__('You can enter many scipers separated by a comma', 'epfl')}
+                        onChange={scipers => setAttributes({ scipers })}
+                    />
+                    <h3>{__('OR', 'epfl')}</h3>
+                    <SelectControl
+                        label={__("Section name", 'epfl')}
+                        value={attributes.section}
+                        options={optionsSectionList}
+                        onChange={section => setAttributes({ section })}
+                    />
+
                 </PanelBody>
-                <PanelBody title={ __( 'Filters', 'epfl' ) }>
+                <PanelBody title={__('Filters', 'epfl')}>
                     <TextControl
-                        label={ __("Course code", 'epfl') }
-                        value={ attributes.courseCode }
-						onChange={ courseCode => setAttributes( { courseCode } ) }
-					/>
+                        label={__("Course code", 'epfl')}
+                        value={attributes.courseCode}
+                        onChange={courseCode => setAttributes({ courseCode })}
+                    />
                     <TextControl
-                        label={ __("Cursus", 'epfl') }
-                        value={ attributes.cursus }
-						onChange={ cursus => setAttributes( { cursus } ) }
-					/>
-                    <SelectControl
-                        label={ __("Teaching language", 'epfl') }
-                        value={ attributes.teachingLang }
-                        options={ optionsTeachingLangList }
-                        onChange={ teachingLang => setAttributes( { teachingLang } ) }
+                        label={__("Cursus", 'epfl')}
+                        value={attributes.cursus}
+                        onChange={cursus => setAttributes({ cursus })}
                     />
                     <SelectControl
-                        label={ __("Semester", 'epfl') }
-                        value={ attributes.semester }
-                        options={ optionsSemesterList }
-                        onChange={ semester => setAttributes( { semester } ) }
+                        label={__("Teaching language", 'epfl')}
+                        value={attributes.teachingLang}
+                        options={optionsTeachingLangList}
+                        onChange={teachingLang => setAttributes({ teachingLang })}
                     />
                     <SelectControl
-                        label={ __("Orientation", 'epfl') }
-                        value={ attributes.orientation }
-                        options={ optionsOrientationList }
-                        onChange={ orientation => setAttributes( { orientation } ) }
+                        label={__("Semester", 'epfl')}
+                        value={attributes.semester}
+                        options={optionsSemesterList}
+                        onChange={semester => setAttributes({ semester })}
+                    />
+                    <SelectControl
+                        label={__("Orientation", 'epfl')}
+                        value={attributes.orientation}
+                        options={optionsOrientationList}
+                        onChange={orientation => setAttributes({ orientation })}
                     />
                 </PanelBody>
             </InspectorControls>

--- a/src/epfl-courses/inspector.js
+++ b/src/epfl-courses/inspector.js
@@ -66,58 +66,58 @@ export default class InspectorControlsCourses extends Component {
 
         content = (
             <InspectorControls>
-                <p><a className="wp-block-help" href={__('https://www.epfl.ch/campus/services/courses-en/', 'epfl')} target="new">{__('Online help', 'epfl')} </a></p>
-                <PanelBody title={__('Select by', 'epfl')}>
+                <p><a className="wp-block-help" href={ __('https://www.epfl.ch/campus/services/courses-en/', 'epfl') } target="new">{ __('Online help', 'epfl') } </a></p>
+                <PanelBody title={ __('Select by', 'epfl') }>
                     <TextControl
-                        label={__('Unit name', 'epfl')}
-                        value={attributes.unit}
-                        help={__('"GETALL" gives all courses in EPFL"', 'epfl')}
-                        onChange={unit => setAttributes({ unit })}
+                        label={ __('Unit name', 'epfl') }
+                        value={ attributes.unit }
+                        help={ __('"GETALL" gives all courses in EPFL"', 'epfl') }
+                        onChange={ unit => setAttributes({ unit }) }
                     />
-                    <h3>{__('OR', 'epfl')}</h3>
+                    <h3>{ __('OR', 'epfl') }</h3>
                     <TextControl
-                        label={__('Scipers', 'epfl')}
-                        value={attributes.scipers}
-                        help={__('You can enter many scipers separated by a comma', 'epfl')}
-                        onChange={scipers => setAttributes({ scipers })}
+                        label={ __('Scipers', 'epfl') }
+                        value={ attributes.scipers }
+                        help={ __('You can enter many scipers separated by a comma', 'epfl') }
+                        onChange={ scipers => setAttributes({ scipers }) }
                     />
                     <h3>{__('OR', 'epfl')}</h3>
                     <SelectControl
-                        label={__("Section name", 'epfl')}
-                        value={attributes.section}
-                        options={optionsSectionList}
-                        onChange={section => setAttributes({ section })}
+                        label={ __("Section name", 'epfl') }
+                        value={ attributes.section }
+                        options={ optionsSectionList }
+                        onChange={ section => setAttributes({ section }) }
                     />
 
                 </PanelBody>
-                <PanelBody title={__('Filters', 'epfl')}>
+                <PanelBody title={ __('Filters', 'epfl') }>
                     <TextControl
-                        label={__("Course code", 'epfl')}
-                        value={attributes.courseCode}
-                        onChange={courseCode => setAttributes({ courseCode })}
+                        label={ __("Course code", 'epfl') }
+                        value={ attributes.courseCode }
+                        onChange={ courseCode => setAttributes({ courseCode }) }
                     />
                     <TextControl
-                        label={__("Cursus", 'epfl')}
-                        value={attributes.cursus}
-                        onChange={cursus => setAttributes({ cursus })}
+                        label={ __("Cursus", 'epfl') }
+                        value={ attributes.cursus }
+                        onChange={ cursus => setAttributes({ cursus }) }
                     />
                     <SelectControl
-                        label={__("Teaching language", 'epfl')}
-                        value={attributes.teachingLang}
-                        options={optionsTeachingLangList}
-                        onChange={teachingLang => setAttributes({ teachingLang })}
+                        label={ __("Teaching language", 'epfl') }
+                        value={ attributes.teachingLang }
+                        options={ optionsTeachingLangList }
+                        onChange={ teachingLang => setAttributes({ teachingLang }) }
                     />
                     <SelectControl
-                        label={__("Semester", 'epfl')}
-                        value={attributes.semester}
-                        options={optionsSemesterList}
-                        onChange={semester => setAttributes({ semester })}
+                        label={ __("Semester", 'epfl') }
+                        value={ attributes.semester }
+                        options={ optionsSemesterList }
+                        onChange={ semester => setAttributes({ semester }) }
                     />
                     <SelectControl
-                        label={__("Orientation", 'epfl')}
-                        value={attributes.orientation}
-                        options={optionsOrientationList}
-                        onChange={orientation => setAttributes({ orientation })}
+                        label={ __("Orientation", 'epfl') }
+                        value={ attributes.orientation }
+                        options={ optionsOrientationList }
+                        onChange= {orientation => setAttributes({ orientation }) }
                     />
                 </PanelBody>
             </InspectorControls>

--- a/src/epfl-courses/inspector.js
+++ b/src/epfl-courses/inspector.js
@@ -23,15 +23,15 @@ export default class InspectorControlsCourses extends Component {
         const { attributes, setAttributes } = this.props
 
         let optionsTeachingLangList = [
-            { value: '', label: __('All', 'epfl') },
-            { value: 'fr', label: __('French', 'epfl') },
-            { value: 'en', label: __('English', 'epfl') },
+            { value: '', label: __('All', 'epfl')},
+            { value: 'fr', label: __('French', 'epfl')},
+            { value: 'en', label: __('English', 'epfl')},
         ];
 
         let optionsSemesterList = [
-            { value: '', label: __('All', 'epfl') },
-            { value: 'ete', label: __('Summer', 'epfl') },
-            { value: 'hiver', label: __('Winter', 'epfl') },
+            { value: '', label: __('All', 'epfl')},
+            { value: 'ete', label: __('Summer', 'epfl')},
+            { value: 'hiver', label: __('Winter', 'epfl')},
         ];
 
         let optionsOrientationList = [

--- a/src/epfl-courses/inspector.js
+++ b/src/epfl-courses/inspector.js
@@ -72,21 +72,21 @@ export default class InspectorControlsCourses extends Component {
                         label={ __('Unit name', 'epfl') }
                         value={ attributes.unit }
                         help={ __('"GETALL" gives all courses in EPFL"', 'epfl') }
-                        onChange={ unit => setAttributes({ unit }) }
+                        onChange={ unit => setAttributes( { unit } ) }
                     />
                     <h3>{ __('OR', 'epfl') }</h3>
                     <TextControl
                         label={ __('Scipers', 'epfl') }
                         value={ attributes.scipers }
                         help={ __('You can enter many scipers separated by a comma', 'epfl') }
-                        onChange={ scipers => setAttributes({ scipers }) }
+                        onChange={ scipers => setAttributes( { scipers } ) }
                     />
                     <h3>{__('OR', 'epfl')}</h3>
                     <SelectControl
                         label={ __("Section name", 'epfl') }
                         value={ attributes.section }
                         options={ optionsSectionList }
-                        onChange={ section => setAttributes({ section }) }
+                        onChange={ section => setAttributes ({ section } ) }
                     />
 
                 </PanelBody>
@@ -94,30 +94,30 @@ export default class InspectorControlsCourses extends Component {
                     <TextControl
                         label={ __("Course code", 'epfl') }
                         value={ attributes.courseCode }
-                        onChange={ courseCode => setAttributes({ courseCode }) }
+                        onChange={ courseCode => setAttributes( { courseCode } ) }
                     />
                     <TextControl
                         label={ __("Cursus", 'epfl') }
                         value={ attributes.cursus }
-                        onChange={ cursus => setAttributes({ cursus }) }
+                        onChange={ cursus => setAttributes( { cursus } ) }
                     />
                     <SelectControl
                         label={ __("Teaching language", 'epfl') }
                         value={ attributes.teachingLang }
                         options={ optionsTeachingLangList }
-                        onChange={ teachingLang => setAttributes({ teachingLang }) }
+                        onChange={ teachingLang => setAttributes( { teachingLang } ) }
                     />
                     <SelectControl
                         label={ __("Semester", 'epfl') }
                         value={ attributes.semester }
                         options={ optionsSemesterList }
-                        onChange={ semester => setAttributes({ semester }) }
+                        onChange={ semester => setAttributes( { semester } ) }
                     />
                     <SelectControl
                         label={ __("Orientation", 'epfl') }
                         value={ attributes.orientation }
                         options={ optionsOrientationList }
-                        onChange= {orientation => setAttributes({ orientation }) }
+                        onChange= {orientation => setAttributes( { orientation } ) }
                     />
                 </PanelBody>
             </InspectorControls>

--- a/src/epfl-courses/inspector.js
+++ b/src/epfl-courses/inspector.js
@@ -67,30 +67,30 @@ export default class InspectorControlsCourses extends Component {
         content = (
             <InspectorControls>
                 <p><a className="wp-block-help" href={ __('https://www.epfl.ch/campus/services/courses-en/', 'epfl') } target="new">{ __('Online help', 'epfl') } </a></p>
-                <PanelBody title={ __('Select by', 'epfl') }>
+                <PanelBody title={ __( 'Select by', 'epfl') }>
                     <TextControl
-                        label={ __('Unit name', 'epfl') }
+                        label={__( 'Unit name', 'epfl')}
                         value={ attributes.unit }
                         help={ __('"GETALL" gives all courses in EPFL"', 'epfl') }
                         onChange={ unit => setAttributes( { unit } ) }
                     />
-                    <h3>{ __('OR', 'epfl') }</h3>
+                    <h3>{__( 'OR', 'epfl')}</h3>
                     <TextControl
-                        label={ __('Scipers', 'epfl') }
+                        label={__( 'Scipers', 'epfl')}
                         value={ attributes.scipers }
                         help={ __('You can enter many scipers separated by a comma', 'epfl') }
                         onChange={ scipers => setAttributes( { scipers } ) }
                     />
                     <h3>{__('OR', 'epfl')}</h3>
                     <SelectControl
-                        label={ __("Section name", 'epfl') }
+                        label={__( 'Section name', 'epfl')}
                         value={ attributes.section }
                         options={ optionsSectionList }
                         onChange={ section => setAttributes ({ section } ) }
                     />
 
                 </PanelBody>
-                <PanelBody title={ __('Filters', 'epfl') }>
+                <PanelBody title={ __( 'Filters', 'epfl' ) }>
                     <TextControl
                         label={ __("Course code", 'epfl') }
                         value={ attributes.courseCode }
@@ -117,7 +117,7 @@ export default class InspectorControlsCourses extends Component {
                         label={ __("Orientation", 'epfl') }
                         value={ attributes.orientation }
                         options={ optionsOrientationList }
-                        onChange= {orientation => setAttributes( { orientation } ) }
+                        onChange={ orientation => setAttributes( { orientation } ) }
                     />
                 </PanelBody>
             </InspectorControls>


### PR DESCRIPTION
Changement du champ "Section" pour mettre une liste déroulante au lieu de texte libre. Pourquoi? bah parce que personne ne savait quel contenu mettre dans ce champ... 😅 

Maintenant, y'a ça
![image](https://user-images.githubusercontent.com/11942430/83642117-b81ca900-a5ae-11ea-9765-aa497e799b12.png)

PS: l'aspirateur a été passé 😉 
