### PR TITLE
Add title for page teaser

### DIFF
--- a/frontend/epfl-page-teaser/controller.php
+++ b/frontend/epfl-page-teaser/controller.php
@@ -9,6 +9,7 @@ use \EPFL\Plugins\Gutenberg\Lib\Utils;
 
 function epfl_page_teaser_block( $attributes ) {
 
+    $title           = Utils::get_sanitized_attribute( $attributes, 'title', '' );
     $page1           = Utils::get_sanitized_attribute( $attributes, 'page1' );
     $page2           = Utils::get_sanitized_attribute( $attributes, 'page2' );
     $page3           = Utils::get_sanitized_attribute( $attributes, 'page3' );
@@ -44,6 +45,10 @@ function epfl_page_teaser_block( $attributes ) {
     }
     $html .= '">';
     $html .= '<div class="container">';
+    if($title != '')
+    {
+        $html .= ' <h3 class="h6 mb-3 '. (($pagesCount < 3) ? ' text-center' : ''). '">'.$title.'</h3>';
+    }
     $html .= '  <div class="card-deck';
     if ($pagesCount < 3) {
         $html .= ' card-deck-line';

--- a/plugin.php
+++ b/plugin.php
@@ -3,7 +3,7 @@
  * Plugin Name: wp-gutenberg-epfl
  * Description: EPFL Gutenberg Blocks
  * Author: WordPress EPFL Team
- * Version: 1.18.2
+ * Version: 1.19.0
  */
 
 namespace EPFL\Plugins\Gutenberg;

--- a/src/epfl-page-teaser/index.js
+++ b/src/epfl-page-teaser/index.js
@@ -8,13 +8,16 @@ registerBlockType(
 	'epfl/page-teaser',
 	{
 		title: __( "EPFL Page Teaser", 'epfl'),
-		description: 'v1.0.3',
+		description: 'v1.0.4',
 		category: 'common',
 		keywords: [
             __( 'page' , 'epfl'),
             __( 'teaser' , 'epfl'),
 		],
 		attributes: {
+			title: {
+				type: 'string',
+			},
 			page1: {
 				type: 'string',
 				default: null,

--- a/src/epfl-page-teaser/inspector.js
+++ b/src/epfl-page-teaser/inspector.js
@@ -13,6 +13,7 @@ const {
     PanelBody,
     ToggleControl,
     Spinner,
+    TextControl,
 } = wp.components
 
 export default class InspectorControlsPageTeaser extends Component {
@@ -79,6 +80,11 @@ export default class InspectorControlsPageTeaser extends Component {
                         />
                     </PanelBody>
                 	</InspectorControls>
+                    <TextControl
+                        label={ __('Title', 'epfl') }
+                        value={ attributes.title }
+                        onChange={ title => setAttributes( { title } ) }
+                    />
 
                     <h4>{ __( 'Pages', 'epfl') }</h4>
 


### PR DESCRIPTION
Ajout de la possibilité de mettre un titre pour une "Page teaser", tout comme c'est fait pour "Custom Teaser". Reprise du code pour afficher le titre, tout simplement.
https://epfl-webvolution.atlassian.net/browse/WEBEVOL-102

