### PR TITLE
Fix/epfl table filter header

### DIFF
--- a/frontend/epfl-table-filter/js/table-filter.js
+++ b/frontend/epfl-table-filter/js/table-filter.js
@@ -57,10 +57,15 @@ $(".epfl-table-filter").each(function(filter_div_index, filter_div) {
         
         // if we have at least one option, 'header' will be in it, so...
 
-        // Changing <td> into <th> in header
-        table.find('tr:first').find('td').changeElementType('th');
-        // Wraping <tr><th> into <thead>
-        table.find('tr:first').wrap('<thead/>').parent().prependTo(table);
+        // There are 2 options for the header. An option from the native block 'table'
+        // and another option 'header & sort' which comes from the custom block epfl-table-filter.
+        // If there is already a header, do not add the 2nd 'custom header'
+        if (table.find('thead').length == 0) {
+          // Changing <td> into <th> in header
+          table.find('tr:first').find('td').changeElementType('th');
+          // Wraping <tr><th> into <thead>
+          table.find('tr:first').wrap('<thead/>').parent().prependTo(table);
+        }
 
         // if we also have to sort table
         if(header_options.includes('sort'))

--- a/plugin.php
+++ b/plugin.php
@@ -3,7 +3,7 @@
  * Plugin Name: wp-gutenberg-epfl
  * Description: EPFL Gutenberg Blocks
  * Author: WordPress EPFL Team
- * Version: 1.20.1
+ * Version: 1.20.2
  */
 
 namespace EPFL\Plugins\Gutenberg;

--- a/src/epfl-table-filter/index.js
+++ b/src/epfl-table-filter/index.js
@@ -55,7 +55,7 @@ let optionsHeader = [
 
 registerBlockType( 'epfl/table-filter', {
 	title: __( 'EPFL Table Filter', 'epfl'),
-	description: 'v1.1.1',
+	description: 'v1.1.2',
 	icon: tableFilterIcon,
 	category: 'common',
 	attributes: getAttributes(),


### PR DESCRIPTION
Il a un problème entre le header du block natif 'table' et le block epfl custom 'epfl-table-filter'.
Donc si le header natif et présent, on n'ajoute pas le header du block 'epfl-table-filter'.