### PR TITLE
Fix missing formatting buttons

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -3,7 +3,7 @@
  * Plugin Name: wp-gutenberg-epfl
  * Description: EPFL Gutenberg Blocks
  * Author: WordPress EPFL Team
- * Version: 1.22.0
+ * Version: 1.22.1
  */
 
 namespace EPFL\Plugins\Gutenberg;

--- a/src/epfl-introduction/index.js
+++ b/src/epfl-introduction/index.js
@@ -20,7 +20,7 @@ const { Fragment } = wp.element;
 
 registerBlockType( 'epfl/introduction', {
 	title: __( 'EPFL Introduction', 'epfl'),
-	description: 'v1.0.3',
+	description: 'v1.0.4',
 	icon: 'text',
 	category: 'common',
 	attributes: {
@@ -66,7 +66,6 @@ registerBlockType( 'epfl/introduction', {
 						onChange={ content => setAttributes( { content } ) }
 						placeholder={ __('Write your text here','epfl')}
 						keepPlaceholderOnFocus = { true }
-						allowedFormats={[]}
                     />
                 </div>
             </Fragment>


### PR DESCRIPTION
Correction d'un problème qui semble être apparu suite au passage en WordPress 5.4. Une option avait été ajoutée par le passé à l'élément `RichText` (probablement en test) et elle ne faisait encore rien dans l'ancienne version de WordPress que nous avions. Pour une raison inconnue, le code est resté et s'est finalement "activé" avec la version 5.4, ce qui a entraîné la disparition des boutons pour formater le texte dans EPFL-Introduction