### PR TITLE
Fix import of deprecated components 

### DIFF
--- a/src/epfl-alert/index.js
+++ b/src/epfl-alert/index.js
@@ -9,7 +9,7 @@ const {
 const {
     InspectorControls,
     RichText,
-} = wp.editor;
+} = wp.blockEditor;
 
 const {
     PanelBody,

--- a/src/epfl-button/index.js
+++ b/src/epfl-button/index.js
@@ -8,7 +8,7 @@ const {
 
 const {
     InspectorControls,
-} = wp.editor;
+} = wp.blockEditor;
 
 const {
     PanelBody,

--- a/src/epfl-caption-cards/index.js
+++ b/src/epfl-caption-cards/index.js
@@ -12,7 +12,7 @@ const {
 const {
     TextControl,
     Placeholder,
-    IconButton,
+    Button,
 } = wp.components;
 
 const { Fragment } = wp.element;
@@ -96,13 +96,13 @@ function CaptionCardPanel ( props ) {
                             label={ __("Image", 'epfl') }
                             instructions={ __('Please, select an image', 'epfl') }
                         >
-                            <IconButton
-                                className="components-icon-button wp-block-image__upload-button button button-large"
+                            <Button
+                                className="components-button.has-icon wp-block-image__upload-button button button-large"
                                 onClick={ open }
                                 icon="upload"
                             >
                                 { __('Upload', 'epfl') }
-                            </IconButton>
+                            </Button>
                         </Placeholder>
                     )}
                 />
@@ -116,13 +116,13 @@ function CaptionCardPanel ( props ) {
 
                     { props.attributes['imageUrl' + index] && (
 
-                    <IconButton
+                    <Button
                         className={'epfl-uploader-remove-image'}
                         onClick={ onRemoveImage }
                         icon="dismiss"
                     >
                         { __('Remove image', 'epfl') }
-                    </IconButton>
+                    </Button>
 
                     ) }
                     </p>

--- a/src/epfl-caption-cards/index.js
+++ b/src/epfl-caption-cards/index.js
@@ -7,7 +7,7 @@ const {
 const {
     InspectorControls,
     MediaUpload
-} = wp.editor;
+} = wp.blockEditor;
 
 const {
     TextControl,

--- a/src/epfl-card-deck/card-panel.js
+++ b/src/epfl-card-deck/card-panel.js
@@ -14,7 +14,7 @@ const {
 const {
     TextControl,
     Placeholder,
-    IconButton,
+    Button,
 } = wp.components;
 
 const { Fragment } = wp.element;
@@ -95,13 +95,13 @@ registerBlockType( 'epfl/card-panel', {
                                     label={ __("Image", 'epfl') }
                                     instructions={ __('Please, select an image', 'epfl') }
                                 >
-                                    <IconButton
-                                        className="components-icon-button wp-block-image__upload-button button button-large"
+                                    <Button
+                                        className="components-button.has-icon wp-block-image__upload-button button button-large"
                                         onClick={ open }
                                         icon="upload"
                                     >
                                         { __('Upload', 'epfl') }
-                                    </IconButton>
+                                    </Button>
                                 </Placeholder>
                             )}
                         />
@@ -115,13 +115,13 @@ registerBlockType( 'epfl/card-panel', {
 
                             { props.attributes.imageUrl && (
 
-                            <IconButton
+                            <Button
                                 className={'epfl-uploader-remove-image'}
                                 onClick={ onRemoveImage }
                                 icon="dismiss"
                             >
                                 { __('Remove image', 'epfl') }
-                            </IconButton>
+                            </Button>
 
                             ) }
                             </p>

--- a/src/epfl-card-deck/card-panel.js
+++ b/src/epfl-card-deck/card-panel.js
@@ -9,7 +9,7 @@ const {
 const {
     MediaUpload,
     InnerBlocks,
-} = wp.editor;
+} = wp.blockEditor;
 
 const {
     TextControl,

--- a/src/epfl-card-deck/index.js
+++ b/src/epfl-card-deck/index.js
@@ -10,7 +10,7 @@ const {
 const {
     InspectorControls,
     InnerBlocks,
-} = wp.editor;
+} = wp.blockEditor;
 
 const {
     PanelBody,

--- a/src/epfl-carousel/index.js
+++ b/src/epfl-carousel/index.js
@@ -16,7 +16,7 @@ const {
     ToggleControl,
     TextControl,
     Placeholder,
-    IconButton,
+    Button,
 } = wp.components;
 
 const { Fragment } = wp.element;
@@ -107,13 +107,13 @@ function CarouselPanel ( props ) {
                             label={ __("Image", 'epfl') }
                             instructions={ __('Please, select an image', 'epfl') }
                         >
-                            <IconButton
-                                className="components-icon-button wp-block-image__upload-button button button-large"
+                            <Button
+                                className="components-button.has-icon wp-block-image__upload-button button button-large"
                                 onClick={ open }
                                 icon="upload"
                             >
                                 { __('Upload', 'epfl') }
-                            </IconButton>
+                            </Button>
                         </Placeholder>
                     )}
                 />
@@ -127,13 +127,13 @@ function CarouselPanel ( props ) {
 
                     { props.attributes['imageUrl' + index] && (
 
-                    <IconButton
+                    <Button
                         className={'epfl-uploader-remove-image'}
                         onClick={ onRemoveImage }
                         icon="dismiss"
                     >
                         { __('Remove image', 'epfl') }
-                    </IconButton>
+                    </Button>
 
                     ) }
                     </p>

--- a/src/epfl-carousel/index.js
+++ b/src/epfl-carousel/index.js
@@ -9,7 +9,7 @@ const {
 const {
     MediaUpload,
 	InspectorControls,
-} = wp.editor;
+} = wp.blockEditor;
 
 const {
     PanelBody,

--- a/src/epfl-contact/index.js
+++ b/src/epfl-contact/index.js
@@ -11,7 +11,7 @@ const {
     InspectorControls,
     RichText,
     InnerBlocks,
-} = wp.editor;
+} = wp.blockEditor;
 
 const {
     PanelBody,

--- a/src/epfl-courses/inspector.js
+++ b/src/epfl-courses/inspector.js
@@ -8,7 +8,7 @@ const {
 
 const {
     InspectorControls,
-} = wp.editor
+} = wp.blockEditor
 
 const {
     PanelBody,

--- a/src/epfl-cover/index.js
+++ b/src/epfl-cover/index.js
@@ -15,7 +15,7 @@ const {
 
 const {
     Placeholder,
-    IconButton,
+    Button,
 	TextareaControl,
 } = wp.components;
 
@@ -76,13 +76,13 @@ registerBlockType( 'epfl/cover', {
                                 label={ __("Image", 'epfl') }
                                 instructions={ __('Please, select an image', 'epfl') }
                             >
-                                <IconButton
-                                    className="components-icon-button wp-block-image__upload-button button button-large"
+                                <Button
+                                    className="components-button.has-icon wp-block-image__upload-button button button-large"
                                     onClick={ open }
                                     icon="upload"
                                 >
                                     { __('Upload', 'epfl') }
-                                </IconButton>
+                                </Button>
                             </Placeholder>
                         )}
                         />
@@ -96,13 +96,13 @@ registerBlockType( 'epfl/cover', {
 
                         { props.isSelected && (
 
-                        <IconButton
+                        <Button
                             className="epfl-uploader-remove-image"
                             onClick={ onRemoveImage }
                             icon="dismiss"
                         >
                             { __('Remove image', 'epfl') }
-                        </IconButton>
+                        </Button>
 
                         ) }
                       </p>

--- a/src/epfl-cover/index.js
+++ b/src/epfl-cover/index.js
@@ -11,7 +11,7 @@ const {
 const {
 	MediaUpload,
 	InspectorControls,
-} = wp.editor;
+} = wp.blockEditor;
 
 const {
     Placeholder,

--- a/src/epfl-custom-highlight/index.js
+++ b/src/epfl-custom-highlight/index.js
@@ -9,7 +9,7 @@ const {
 const {
 	MediaUpload,
 	InspectorControls,
-} = wp.editor;
+} = wp.blockEditor;
 
 const {
     Placeholder,

--- a/src/epfl-custom-highlight/index.js
+++ b/src/epfl-custom-highlight/index.js
@@ -13,7 +13,7 @@ const {
 
 const {
     Placeholder,
-    IconButton,
+    Button,
 	TextControl,
 	TextareaControl,
 	RadioControl,
@@ -122,13 +122,13 @@ registerBlockType( 'epfl/custom-highlight', {
                                 label={ __("Image", 'epfl') }
                                 instructions={ __('Please, select an image', 'epfl') }
                             >
-                                <IconButton
-                                    className="components-icon-button wp-block-image__upload-button button button-large"
+                                <Button
+                                    className="components-button.has-icon wp-block-image__upload-button button button-large"
                                     onClick={ open }
                                     icon="upload"
                                 >
                                     { __('Upload', 'epfl') }
-                                </IconButton>
+                                </Button>
                             </Placeholder>
                         )}
                         />
@@ -142,13 +142,13 @@ registerBlockType( 'epfl/custom-highlight', {
 
                         { props.isSelected && (
 
-                        <IconButton
+                        <Button
                             className="epfl-uploader-remove-image"
                             onClick={ onRemoveImage }
                             icon="dismiss"
                         >
                             { __('Remove image', 'epfl') }
-                        </IconButton>
+                        </Button>
 
                         ) }
                       </p>

--- a/src/epfl-custom-teaser/index.js
+++ b/src/epfl-custom-teaser/index.js
@@ -7,7 +7,7 @@ const {
 const {
     MediaUpload,
 	InspectorControls,
-} = wp.editor;
+} = wp.blockEditor;
 
 const {
     PanelBody,

--- a/src/epfl-custom-teaser/index.js
+++ b/src/epfl-custom-teaser/index.js
@@ -14,7 +14,7 @@ const {
     ToggleControl,
     TextControl,
     Placeholder,
-    IconButton,
+    Button,
 } = wp.components;
 
 const { Fragment } = wp.element;
@@ -119,13 +119,13 @@ function CustomTeaserPanel ( props ) {
                             label={ __("Image", 'epfl') }
                             instructions={ __('Please, select an image', 'epfl') }
                         >
-                            <IconButton
-                                className="components-icon-button wp-block-image__upload-button button button-large"
+                            <Button
+                                className="components-button.has-icon wp-block-image__upload-button button button-large"
                                 onClick={ open }
                                 icon="upload"
                             >
                                 { __('Upload', 'epfl') }
-                            </IconButton>
+                            </Button>
                         </Placeholder>
                     )}
                 />
@@ -139,13 +139,13 @@ function CustomTeaserPanel ( props ) {
 
                     { props.attributes['imageUrl' + index] && (
 
-                    <IconButton
+                    <Button
                         className={'epfl-uploader-remove-image'}
                         onClick={ onRemoveImage }
                         icon="dismiss"
                     >
                         { __('Remove image', 'epfl') }
-                    </IconButton>
+                    </Button>
 
                     ) }
                     </p>

--- a/src/epfl-definition-list/index.js
+++ b/src/epfl-definition-list/index.js
@@ -8,7 +8,7 @@ const {
     MediaUpload,
     InspectorControls,
     RichText,
-} = wp.editor;
+} = wp.blockEditor;
 
 const {
     PanelBody,

--- a/src/epfl-faq/faq-item.js
+++ b/src/epfl-faq/faq-item.js
@@ -8,7 +8,7 @@ const {
 
 const {
     InnerBlocks,
-} = wp.editor;
+} = wp.blockEditor;
 
 const {
     TextControl,
@@ -60,7 +60,7 @@ registerBlockType( 'epfl/faq-item', {
                             template={ TEMPLATE }
                             templateLock="all"
                            />
-                    
+
                 </div>
             </Fragment>
 		)

--- a/src/epfl-faq/index.js
+++ b/src/epfl-faq/index.js
@@ -10,7 +10,7 @@ const {
 const {
     InspectorControls,
     InnerBlocks,
-} = wp.editor;
+} = wp.blockEditor;
 
 const {
 } = wp.components;

--- a/src/epfl-gallery/index.js
+++ b/src/epfl-gallery/index.js
@@ -9,7 +9,7 @@ const {
 const {
     InspectorControls,
     InnerBlocks,
-} = wp.editor;
+} = wp.blockEditor;
 
 const {
     PanelBody,

--- a/src/epfl-google-forms/index.js
+++ b/src/epfl-google-forms/index.js
@@ -9,7 +9,7 @@ const {
 
 const {
 	InspectorControls,
-} = wp.editor;
+} = wp.blockEditor;
 
 const {
 	TextareaControl,

--- a/src/epfl-hero/index.js
+++ b/src/epfl-hero/index.js
@@ -12,7 +12,7 @@ const {
 
 const {
     Placeholder,
-    IconButton,
+    Button,
     PanelBody,
     TextControl,
     TextareaControl,
@@ -97,13 +97,13 @@ registerBlockType( 'epfl/hero', {
                                 label={ __("Image", 'epfl') }
                                 instructions={ __('Please, select an image', 'epfl') }
                             >
-                                <IconButton
-                                    className="components-icon-button wp-block-image__upload-button button button-large"
+                                <Button
+                                    className="components-button.has-icon wp-block-image__upload-button button button-large"
                                     onClick={ open }
                                     icon="upload"
                                 >
                                     { __('Upload', 'epfl') }
-                                </IconButton>
+                                </Button>
                             </Placeholder>
                         )}
                         />
@@ -117,13 +117,13 @@ registerBlockType( 'epfl/hero', {
 
                         { props.isSelected && (
 
-                        <IconButton
+                        <Button
                             className="epfl-uploader-remove-image"
                             onClick={ onRemoveImage }
                             icon="dismiss"
                         >
                             { __('Remove image', 'epfl') }
-                        </IconButton>
+                        </Button>
 
                         ) }
                       </p>

--- a/src/epfl-hero/index.js
+++ b/src/epfl-hero/index.js
@@ -8,7 +8,7 @@ const {
     MediaUpload,
     InspectorControls,
     RichText,
-} = wp.editor;
+} = wp.blockEditor;
 
 const {
     Placeholder,

--- a/src/epfl-infoscience-search/inspector.js
+++ b/src/epfl-infoscience-search/inspector.js
@@ -5,7 +5,7 @@ const { Component } = wp.element
 
 const {
 	InspectorControls,
-} = wp.editor
+} = wp.blockEditor
 
 const {
     PanelBody,

--- a/src/epfl-introduction/index.js
+++ b/src/epfl-introduction/index.js
@@ -7,7 +7,7 @@ const {
 const {
 	InspectorControls,
 	RichText,
-} = wp.editor;
+} = wp.blockEditor;
 
 const {
     PanelBody,

--- a/src/epfl-links-group/index.js
+++ b/src/epfl-links-group/index.js
@@ -11,7 +11,7 @@ const {
 
 const {
 	InspectorControls,
-} = wp.editor
+} = wp.blockEditor
 
 const { Fragment } = wp.element;
 

--- a/src/epfl-map/index.js
+++ b/src/epfl-map/index.js
@@ -6,7 +6,7 @@ const {
 
 const {
 	InspectorControls,
-} = wp.editor;
+} = wp.blockEditor;
 
 const {
     PanelBody,

--- a/src/epfl-memento/inspector.js
+++ b/src/epfl-memento/inspector.js
@@ -6,7 +6,7 @@ const { Component } = wp.element
 
 const {
 	InspectorControls,
-} = wp.editor
+} = wp.blockEditor
 
 const {
     PanelBody,

--- a/src/epfl-mini-card-deck/index.js
+++ b/src/epfl-mini-card-deck/index.js
@@ -10,7 +10,7 @@ const {
 const {
     InspectorControls,
     InnerBlocks,
-} = wp.editor;
+} = wp.blockEditor;
 
 const {
     PanelBody,

--- a/src/epfl-mini-card-deck/mini-card-panel.js
+++ b/src/epfl-mini-card-deck/mini-card-panel.js
@@ -9,7 +9,7 @@ const {
 const {
     MediaUpload,
     InnerBlocks,
-} = wp.editor;
+} = wp.blockEditor;
 
 const {
     TextControl,

--- a/src/epfl-mini-card-deck/mini-card-panel.js
+++ b/src/epfl-mini-card-deck/mini-card-panel.js
@@ -14,7 +14,7 @@ const {
 const {
     TextControl,
     Placeholder,
-    IconButton,
+    Button,
     ToggleControl,
 } = wp.components;
 
@@ -75,7 +75,7 @@ registerBlockType( 'epfl/mini-card-panel', {
             <Fragment>
                 <div className={ className }>
                     <h4>{ __('Mini card', 'epfl') }</h4>
-                    
+
                     <TextControl
                         label={ __('Link', 'epfl') }
                         value={ attributes.link }
@@ -86,7 +86,7 @@ registerBlockType( 'epfl/mini-card-panel', {
                             checked={ attributes.openLinkNewTab  }
                             onChange={ openLinkNewTab  => setAttributes( { openLinkNewTab  } ) }
                     />
-                    
+
                     { isSelected ? (
                         <MediaUpload
                             onSelect={ onImageSelect }
@@ -98,13 +98,13 @@ registerBlockType( 'epfl/mini-card-panel', {
                                     label={ __("Image", 'epfl') }
                                     instructions={ __('Please, select an image', 'epfl') }
                                 >
-                                    <IconButton
-                                        className="components-icon-button wp-block-image__upload-button button button-large"
+                                    <Button
+                                        className="components-button.has-icon wp-block-image__upload-button button button-large"
                                         onClick={ open }
                                         icon="upload"
                                     >
                                         { __('Upload', 'epfl') }
-                                    </IconButton>
+                                    </Button>
                                 </Placeholder>
                             )}
                         />
@@ -118,13 +118,13 @@ registerBlockType( 'epfl/mini-card-panel', {
 
                             { props.attributes.imageUrl && (
 
-                            <IconButton
+                            <Button
                                 className={'epfl-uploader-remove-image'}
                                 onClick={ onRemoveImage }
                                 icon="dismiss"
                             >
                                 { __('Remove image', 'epfl') }
-                            </IconButton>
+                            </Button>
 
                             ) }
                             </p>

--- a/src/epfl-news/inspector.js
+++ b/src/epfl-news/inspector.js
@@ -7,7 +7,7 @@ const { Component } = wp.element
 
 const {
 	InspectorControls,
-} = wp.editor
+} = wp.blockEditor
 
 const {
     PanelBody,

--- a/src/epfl-page-highlight/inspector.js
+++ b/src/epfl-page-highlight/inspector.js
@@ -8,7 +8,7 @@ const { Component } = wp.element
 
 const {
 	InspectorControls,
-} = wp.editor
+} = wp.blockEditor
 
 const {
     PanelBody,

--- a/src/epfl-page-teaser/inspector.js
+++ b/src/epfl-page-teaser/inspector.js
@@ -7,7 +7,7 @@ const { Component } = wp.element
 
 const {
 	InspectorControls,
-} = wp.editor
+} = wp.blockEditor
 
 const {
     PanelBody,

--- a/src/epfl-pdf-flipbook/index.js
+++ b/src/epfl-pdf-flipbook/index.js
@@ -14,7 +14,7 @@ const {
 
 const {
     Placeholder,
-    IconButton,
+    Button,
 } = wp.components;
 
 const { Fragment } = wp.element;
@@ -72,13 +72,13 @@ registerBlockType( 'epfl/pdf-flipbook', {
                                 label={ __("PDF", 'epfl') }
                                 instructions={ __('Please, select a PDF', 'epfl') }
                             >
-                                <IconButton
-                                    className="components-icon-button wp-block-file__upload-button button button-large"
+                                <Button
+                                    className="components-button.has-icon wp-block-file__upload-button button button-large"
                                     onClick={ open }
                                     icon="upload"
                                 >
                                     { __('Upload', 'epfl') }
-                                </IconButton>
+                                </Button>
                             </Placeholder>
                         )}
                         />
@@ -86,13 +86,13 @@ registerBlockType( 'epfl/pdf-flipbook', {
                         <p className="epfl-uploader-file-wrapper">
 							{ attributes.pdfUrl }
 
-                        <IconButton
+                        <Button
                             className="epfl-uploader-remove-file"
                             onClick={ onRemovePDF }
                             icon="dismiss"
                         >
                             { __('Remove PDF', 'epfl') }
-                        </IconButton>
+                        </Button>
 
                       </p>
                 )}

--- a/src/epfl-pdf-flipbook/index.js
+++ b/src/epfl-pdf-flipbook/index.js
@@ -10,7 +10,7 @@ const {
 const {
 	MediaUpload,
 	InspectorControls,
-} = wp.editor;
+} = wp.blockEditor;
 
 const {
     Placeholder,

--- a/src/epfl-people/inspector.js
+++ b/src/epfl-people/inspector.js
@@ -8,7 +8,7 @@ const {
 
 const {
 	InspectorControls,
-} = wp.editor
+} = wp.blockEditor
 
 const {
     PanelBody,

--- a/src/epfl-post-highlight/inspector.js
+++ b/src/epfl-post-highlight/inspector.js
@@ -8,7 +8,7 @@ const { Component } = wp.element
 
 const {
 	InspectorControls,
-} = wp.editor
+} = wp.blockEditor
 
 const {
     PanelBody,

--- a/src/epfl-post-teaser/inspector.js
+++ b/src/epfl-post-teaser/inspector.js
@@ -7,7 +7,7 @@ const { Component } = wp.element
 
 const {
 	InspectorControls,
-} = wp.editor
+} = wp.blockEditor
 
 const {
     PanelBody,

--- a/src/epfl-quote/index.js
+++ b/src/epfl-quote/index.js
@@ -13,7 +13,7 @@ const {
 
 const {
     Placeholder,
-    IconButton,
+    Button,
     TextareaControl,
     TextControl,
 } = wp.components;
@@ -81,13 +81,13 @@ registerBlockType( 'epfl/quote', {
                                 label={ __("Image", 'epfl') }
                                 instructions={ __('Please, select a square image', 'epfl') }
                             >
-                                <IconButton
-                                    className="components-icon-button wp-block-image__upload-button button button-large"
+                                <Button
+                                    className="components-button.has-icon wp-block-image__upload-button button button-large"
                                     onClick={ open }
                                     icon="upload"
                                 >
                                     { __('Upload', 'epfl') }
-                                </IconButton>
+                                </Button>
                             </Placeholder>
                         )}
                         />
@@ -101,13 +101,13 @@ registerBlockType( 'epfl/quote', {
 
                         { props.isSelected && (
 
-                        <IconButton
+                        <Button
                             className="epfl-uploader-remove-image"
                             onClick={ onRemoveImage }
                             icon="dismiss"
                         >
                             { __('Remove image', 'epfl') }
-                        </IconButton>
+                        </Button>
 
                         ) }
                       </p>

--- a/src/epfl-quote/index.js
+++ b/src/epfl-quote/index.js
@@ -9,7 +9,7 @@ const {
 const {
 	MediaUpload,
 	InspectorControls,
-} = wp.editor;
+} = wp.blockEditor;
 
 const {
     Placeholder,

--- a/src/epfl-scheduler/index.js
+++ b/src/epfl-scheduler/index.js
@@ -10,7 +10,7 @@ const {
     InspectorControls,
     RichText,
     InnerBlocks,
-} = wp.editor;
+} = wp.blockEditor;
 
 const {
     PanelBody,

--- a/src/epfl-social-feed/index.js
+++ b/src/epfl-social-feed/index.js
@@ -8,7 +8,7 @@ const {
 
 const {
 	InspectorControls,
-} = wp.editor;
+} = wp.blockEditor;
 
 const {
     PanelBody,

--- a/src/epfl-table-filter/index.js
+++ b/src/epfl-table-filter/index.js
@@ -10,7 +10,7 @@ const {
 const {
     InspectorControls,
     InnerBlocks,
-} = wp.editor;
+} = wp.blockEditor;
 
 const {
     PanelBody,

--- a/src/epfl-table/index.js
+++ b/src/epfl-table/index.js
@@ -10,7 +10,7 @@ const {
 const {
     InspectorControls,
     InnerBlocks,
-} = wp.editor;
+} = wp.blockEditor;
 
 const {
     PanelBody,

--- a/src/epfl-tableau/index.js
+++ b/src/epfl-tableau/index.js
@@ -10,7 +10,7 @@ const {
 
 const {
 	InspectorControls,
-} = wp.editor;
+} = wp.blockEditor;
 
 const {
     TextControl,

--- a/src/epfl-toggle/index.js
+++ b/src/epfl-toggle/index.js
@@ -11,7 +11,7 @@ const {
     InspectorControls,
 	PlainText,
 	InnerBlocks,
-} = wp.editor;
+} = wp.blockEditor;
 
 const {
     PanelBody,

--- a/src/epfl-video/index.js
+++ b/src/epfl-video/index.js
@@ -8,7 +8,7 @@ const {
 
 const {
 	InspectorControls,
-} = wp.editor;
+} = wp.blockEditor;
 
 const {
     PanelBody,


### PR DESCRIPTION
Fix deprecated :
- IconButton to Button https://make.wordpress.org/core/2020/02/13/an-updated-button-component-in-wordpress-5-4/
- wp.editor to wp.blockEditor https://make.wordpress.org/core/2019/04/09/the-block-editor-javascript-module-in-5-2/