### PR TITLE
Fix faq strangelings

### DIFF
--- a/frontend/epfl-faq/js/faq-header.js
+++ b/frontend/epfl-faq/js/faq-header.js
@@ -1,11 +1,11 @@
 // Looping through faq blocks
-$(".epfl-faq-header").each(function(header_ul_index, header_ul) {
+jQuery(".epfl-faq-header").each(function(header_ul_index, header_ul) {
 
     // Looping through questions inside current faq block
-    $(header_ul).parent().find('.faq-item-question').each(function(question_item_index, question_item) {
+    jQuery(header_ul).parent().find('.faq-item-question').each(function(question_item_index, question_item) {
 
         // Adding link in header
-        $(header_ul).append('<li><a href="#'+$(question_item).parent().attr('id')+'">'+$(question_item).html()+'</a></li>');
+        jQuery(header_ul).append('<li><a href="#'+jQuery(question_item).parent().attr('id')+'">'+jQuery(question_item).html()+'</a></li>');
     });
 
 });

--- a/src/epfl-faq/faq-item.js
+++ b/src/epfl-faq/faq-item.js
@@ -17,7 +17,7 @@ const {
 const { Fragment } = wp.element;
 
 const TEMPLATE = [
-	['tadv/classic-paragraph', {}, [] ],
+	['core/freeform', {}, [] ],
 ]
 
 const getAttributes = () => {


### PR DESCRIPTION
J'ai quelques soucis sur mon environnement local avec le block FAQ.

- $ undefined
- missing adv/classic-editor -> est-ce que ce changement a un impact sur l'existant ? car selon Lucien, le fait que core/freeform soit sauvé ainsi : `<p>content</p>` poserait un problème car détruirerait le contenu. Contrairement à adv/classic-editor qui wrap le contenu avec une délimitation de block.


Etrangement, le problème n'est pas en production. Je mets ici les différents fixes, au cas où le besoin apparaitrait.
