### PR TITLE
Fix warning for polylex looping on non-existent subcategories

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name:     wp-gutenberg-epfl
  * Description:     EPFL Gutenberg Blocks
- * Version:         2.4.1
+ * Version:         2.4.2
  * Author:          WordPress EPFL Team
  * License:         GPL-2.0-or-later
  * License URI:     https://www.gnu.org/licenses/gpl-2.0.html

--- a/shortcodes/epfl-polylex-search/controller.php
+++ b/shortcodes/epfl-polylex-search/controller.php
@@ -64,7 +64,7 @@ function polylex_filter_out_unused_language($lexes) {
       $lex->category = $lex->category->nameFr;
       unset($lex->category->nameEn);
 
-      $lex_subcategories = $lex->subcategories;
+      $lex_subcategories = $lex->subcategories ?? [];
       unset($lex->subcategories);
       $lex->subcategories = [];
       foreach ($lex_subcategories as $subcategory) {
@@ -85,7 +85,7 @@ function polylex_filter_out_unused_language($lexes) {
       $lex->category = $lex->category->nameEn;
       unset($lex->category->nameFr);
 
-      $lex_subcategories = $lex->subcategories;
+      $lex_subcategories = $lex->subcategories ?? [];
       unset($lex->subcategories);
       $lex->subcategories = [];
       foreach ($lex_subcategories as $subcategory) {


### PR DESCRIPTION
Will fix `PHP Warning:  Invalid argument supplied for foreach()` in polylex