### PR TITLE
Fix/memento api rest change

### DIFF
--- a/frontend/epfl-memento/templates/slider.php
+++ b/frontend/epfl-memento/templates/slider.php
@@ -26,7 +26,7 @@
 
             $is_first_event = ($count==1);
             $is_just_finished = is_just_finished($event->end_date, $event->end_time);
-            $is_inscription_required = is_inscription_required($event->invitation);
+            $is_inscription_required = is_inscription_required($event->registration);
 
             if ($is_first_event and $display_first_event) {
 

--- a/frontend/epfl-memento/utils.php
+++ b/frontend/epfl-memento/utils.php
@@ -61,8 +61,9 @@ function is_just_finished($end_date, $end_time) {
 /**
  *
  */
-function is_inscription_required($invitation) {
-    return ($invitation === "Registration required");
+function is_inscription_required($registration) {
+    // id=1 => "Registration required"
+    return ($registration->id === 1);
 }
 
 function get_event() {

--- a/plugin.php
+++ b/plugin.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name:     wp-gutenberg-epfl
  * Description:     EPFL Gutenberg Blocks
- * Version:         2.4.2
+ * Version:         2.4.3
  * Author:          WordPress EPFL Team
  * License:         GPL-2.0-or-later
  * License URI:     https://www.gnu.org/licenses/gpl-2.0.html

--- a/src/epfl-memento/index.js
+++ b/src/epfl-memento/index.js
@@ -11,7 +11,7 @@ import PreviewMemento from './preview'
 import InspectorControlsMemento from './inspector'
 import './utils.js';
 
-export const version = "v1.1.3";
+export const version = "v1.1.4";
 
 const {__} = wp.i18n
 const {registerBlockType} = wp.blocks

--- a/src/epfl-memento/inspector.js
+++ b/src/epfl-memento/inspector.js
@@ -79,7 +79,9 @@ export default class InspectorControlsMemento extends Component {
             ];
 
             this.state.categories.forEach(category => {
-                optionsCategoriesList.push({ label: category.en_label, value: category.id });
+                if (category.activated) {
+                    optionsCategoriesList.push({ label: category.en_label, value: category.id });
+                }
             });
 
             let optionsYearsList = [


### PR DESCRIPTION
Il y a eu des petits changements dans l'API REST de memento qui nécessite des changements du bloc memento de WP.
- le champ invitation est remplacé par le champ registration avec une structure différente
- les catégories ont un nouveau champ activated

API REST Memento :
- https://memento.epfl.ch/api/v1/mementos/1/events/?format=json&lang=en,fr&limit=10
- https://memento.epfl.ch/api/v1/categories/

