### PR TITLE
Fix the way we sanitize urls

### DIFF
--- a/frontend/epfl-button/controller.php
+++ b/frontend/epfl-button/controller.php
@@ -10,20 +10,20 @@ function epfl_button_block( $attributes ) {
     if (!$attributes) return;
 
     $text               = Utils::get_sanitized_attribute( $attributes, 'text' );
-    $link               = Utils::get_sanitized_attribute( $attributes, 'link' );
+    $link               = Utils::get_sanitized_url( $attributes, 'link' );
     $button_style       = Utils::get_sanitized_attribute( $attributes, 'buttonStyle', 'primary' );
     $button_align       = Utils::get_sanitized_attribute( $attributes, 'buttonAlign', 'left' );
     $open_link_new_tab  = Utils::get_sanitized_attribute( $attributes, 'openLinkNewTab', False);
-    
+
     ob_start();
 
     if($button_align == 'centered') echo '<center>';
 ?>
-    
+
     <a href="<?php echo $link; ?>" <?php if($open_link_new_tab): ?>target="_blank" rel="noopener"<?php endif; ?>>
         <button class="btn btn-<?php echo $button_style; ?>"><?php echo $text; ?></button>
     </a>
-    
+
 
 <?php
     if($button_align == 'centered') echo '</center>';

--- a/frontend/epfl-caption-cards/controller.php
+++ b/frontend/epfl-caption-cards/controller.php
@@ -11,11 +11,11 @@ function epfl_caption_cards_block( $attributes ) {
     if (!$attributes) return;
 
     for ($i = 1; $i <= 10; $i++) {
-        
+
         if (array_key_exists('title'.$i, $attributes)) {
             $attributes['title'.$i]    = Utils::get_sanitized_attribute( $attributes, 'title'.$i );
             $attributes['subtitle'.$i] = Utils::get_sanitized_attribute( $attributes, 'subtitle'.$i );
-            $attributes['link'.$i]     = Utils::get_sanitized_attribute( $attributes, 'link'.$i);
+            $attributes['link'.$i]     = Utils::get_sanitized_url( $attributes, 'link'.$i);
             $attributes['imageId'.$i]  = Utils::get_sanitized_attribute( $attributes, 'imageId'.$i);
         }
     }

--- a/frontend/epfl-card-deck/controller.php
+++ b/frontend/epfl-card-deck/controller.php
@@ -14,7 +14,7 @@ require_once(dirname(__FILE__).'/../lib/utils.php');
 function epfl_card_panel_block($attributes, $inner_content)
 {
     $title      = Utils::get_sanitized_attribute( $attributes, 'title' );
-    $link       = Utils::get_sanitized_attribute( $attributes, 'link' );
+    $link       = Utils::get_sanitized_url( $attributes, 'link' );
     $image_id   = Utils::get_sanitized_attribute( $attributes, 'imageId' );
     $image_url  = Utils::get_sanitized_attribute( $attributes, 'imageUrl' );
 

--- a/frontend/epfl-carousel/controller.php
+++ b/frontend/epfl-carousel/controller.php
@@ -21,20 +21,20 @@ function epfl_carousel_block( $attributes ) {
         }
 
         $attributes['imageId'.$i]       = Utils::get_sanitized_attribute( $attributes, 'imageId'.$i );
-        $attributes['url'.$i]           = Utils::get_sanitized_attribute( $attributes, 'url'.$i );
+        $attributes['url'.$i]           = Utils::get_sanitized_url( $attributes, 'url'.$i );
         $attributes['description'.$i]   = Utils::get_sanitized_attribute( $attributes, 'description'.$i );
-        
+
     }
 
     $open_links_new_tab = Utils::get_sanitized_attribute( $attributes, 'openLinksNewTab', '') != '';
-    
+
     ob_start();
 ?>
 
 <div class="container-full">
 <div id="carouselNews" class="carousel slide carousel-highlighted-news" data-ride="carousel" data-interval="6000">
   <div class="carousel-inner">
-    
+
 
     <?php
       for($i = 1; $i <= $MAX_ELEMENTS; $i++):
@@ -89,11 +89,11 @@ function epfl_carousel_block( $attributes ) {
   </div>
 
   <ol class="carousel-indicators">
-  <?php 
+  <?php
   $slide_index = 0;
   for($i = 1; $i <= $MAX_ELEMENTS; $i++)
   {
-    
+
     if ($attributes['title'.$i])
     {
       $class = ($i==1)?'class="active"':'';

--- a/frontend/epfl-custom-highlight/controller.php
+++ b/frontend/epfl-custom-highlight/controller.php
@@ -12,7 +12,7 @@ function epfl_custom_highlight_block( $attributes ) {
     $title          = Utils::get_sanitized_attribute( $attributes, 'title' );
     $description    = Utils::get_sanitized_attribute( $attributes, 'description' );
     $image_id       = Utils::get_sanitized_attribute( $attributes, 'imageId' );
-    $link           = Utils::get_sanitized_attribute( $attributes, 'link' );
+    $link           = Utils::get_sanitized_url( $attributes, 'link' );
     $button_label   = Utils::get_sanitized_attribute( $attributes, 'buttonLabel' );
     $layout         = Utils::get_sanitized_attribute( $attributes, 'layout' );
 

--- a/frontend/epfl-custom-teaser/controller.php
+++ b/frontend/epfl-custom-teaser/controller.php
@@ -19,10 +19,10 @@ function epfl_custom_teaser_block( $attributes ) {
         }
 
         $attributes['imageId'.$i]       = Utils::get_sanitized_attribute( $attributes, 'imageId'.$i );
-        $attributes['url'.$i]           = Utils::get_sanitized_attribute( $attributes, 'url'.$i );
+        $attributes['url'.$i]           = Utils::get_sanitized_url( $attributes, 'url'.$i );
         $attributes['buttonLabel'.$i]   = Utils::get_sanitized_attribute( $attributes, 'buttonLabel'.$i );
         $attributes['excerpt'.$i]       = Utils::get_sanitized_attribute( $attributes, 'excerpt'.$i );
-        
+
     }
 
     $attributes['grayBackground'] = Utils::get_sanitized_attribute( $attributes, 'grayBackground', False);

--- a/frontend/epfl-google-forms/controller.php
+++ b/frontend/epfl-google-forms/controller.php
@@ -14,7 +14,7 @@ function epfl_google_forms_block( $attributes ) {
     This block also allow to use others subdomains of Google (.google.com) like maps, calendar, etc...
     */
 
-    $url = Utils::get_sanitized_attribute( $attributes, 'url', null);
+    $url = Utils::get_sanitized_url( $attributes, 'url', null);
     $height = Utils::get_sanitized_attribute( $attributes, 'height', null);
 
 
@@ -25,7 +25,7 @@ function epfl_google_forms_block( $attributes ) {
     }
     /* Extract host name to check it */
     $url_host = parse_url($url, PHP_URL_HOST);
-    
+
     /* Check that iframe has a Google host as source */
     if(preg_match('/\.google\.com$/', $url_host) !== 1)
     {

--- a/frontend/epfl-links-group/controller.php
+++ b/frontend/epfl-links-group/controller.php
@@ -8,7 +8,7 @@ use \EPFL\Plugins\Gutenberg\Lib\Utils;
 require_once(dirname(__FILE__).'/../lib/utils.php');
 
 function epfl_links_group_block( $attributes ) {
-  $main_url           = Utils::get_sanitized_attribute( $attributes, 'mainUrl' );
+  $main_url           = Utils::get_sanitized_url( $attributes, 'mainUrl' );
   $title              = Utils::get_sanitized_attribute( $attributes, 'title' );
   $open_links_new_tab = Utils::get_sanitized_attribute( $attributes, 'openLinksNewTab' );
 

--- a/frontend/epfl-mini-card-deck/controller.php
+++ b/frontend/epfl-mini-card-deck/controller.php
@@ -14,7 +14,7 @@ require_once(dirname(__FILE__).'/../lib/utils.php');
 function epfl_mini_card_panel_block($attributes)
 {
     $legend         = Utils::get_sanitized_attribute( $attributes, 'legend' );
-    $link           = Utils::get_sanitized_attribute( $attributes, 'link' );
+    $link           = Utils::get_sanitized_url( $attributes, 'link' );
     $image_id       = Utils::get_sanitized_attribute( $attributes, 'imageId' );
     $image_url      = Utils::get_sanitized_attribute( $attributes, 'imageUrl' );
     $openLinkNewTab = Utils::get_sanitized_attribute( $attributes, 'openLinkNewTab' , false);

--- a/frontend/epfl-social-feed/controller.php
+++ b/frontend/epfl-social-feed/controller.php
@@ -17,9 +17,9 @@ function epfl_social_feed_block( $attributes ) {
     $attributes['width']        = Utils::get_sanitized_attribute( $attributes, 'width', DEFAULT_WIDTH );
     $attributes['twitterLimit'] = Utils::get_sanitized_attribute( $attributes, 'twitterLimit' );
     if(intval($attributes['twitterLimit']) == 0)$attributes['twitterLimit'] = '';
-    $attributes['twitterUrl']   = Utils::get_sanitized_attribute( $attributes, 'twitterUrl' );
-    $attributes['instagramUrl'] = Utils::get_sanitized_attribute( $attributes, 'instagramUrl' );
-    $attributes['facebookUrl']  = Utils::get_sanitized_attribute( $attributes, 'facebookUrl' );
+    $attributes['twitterUrl']   = Utils::get_sanitized_url( $attributes, 'twitterUrl' );
+    $attributes['instagramUrl'] = Utils::get_sanitized_url( $attributes, 'instagramUrl' );
+    $attributes['facebookUrl']  = Utils::get_sanitized_url( $attributes, 'facebookUrl' );
 
     return epfl_social_feed_view($attributes['twitterUrl'],
                                 $attributes['twitterLimit'],

--- a/frontend/lib/utils.php
+++ b/frontend/lib/utils.php
@@ -170,6 +170,16 @@ Class Utils
         return  sanitize_text_field((array_key_exists($name, $attributes))? $attributes[$name]: $default);
     }
 
+    /**
+     * Escape and returns an url who's in the given attributes associative array. If not in array,
+     * $default val is returned
+     */
+    public static function get_sanitized_url($attributes, $name, $default="")
+    {
+        return  esc_url((array_key_exists($name, $attributes))? $attributes[$name]: $default);
+    }
+
+
 
     /**
      * Tells if an attribute associated with a Richtext field contains somethings.

--- a/plugin.php
+++ b/plugin.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name:     wp-gutenberg-epfl
  * Description:     EPFL Gutenberg Blocks
- * Version:         2.5.2
+ * Version:         2.5.3
  * Author:          WordPress EPFL Team
  * License:         GPL-2.0-or-later
  * License URI:     https://www.gnu.org/licenses/gpl-2.0.html


### PR DESCRIPTION
Because some urls where destroyed by the sanitize_text_field method, switch to esc_url.

Example of url that should be valid but is currently destroyed :
https://infoscience.epfl.ch/search?ln=fr&cc=Infoscience%2FResearch%2FCDM%2FMTEI&p=&f=&rm=&ln=fr&sf=&so=d&rg=500&c=Infoscience%2FResearch%2FCDM%2FMTEI&c=&of=hb&fct__1=Books