### PR TITLE
[fix] get_sanitized_url(): escape only simple and double quotes

### DIFF
--- a/frontend/lib/utils.php
+++ b/frontend/lib/utils.php
@@ -176,7 +176,8 @@ Class Utils
      */
     public static function get_sanitized_url($attributes, $name, $default="")
     {
-        return  esc_url((array_key_exists($name, $attributes))? $attributes[$name]: $default);
+        $value = (array_key_exists($name, $attributes))? $attributes[$name]: $default;
+        return preg_replace_callback('(\'|")', function($x) { return htmlentities($x[0], ENT_QUOTES); }, $value);
     }
 
 

--- a/frontend/lib/utils.php
+++ b/frontend/lib/utils.php
@@ -177,10 +177,25 @@ Class Utils
     public static function get_sanitized_url($attributes, $name, $default="")
     {
         $value = (array_key_exists($name, $attributes))? $attributes[$name]: $default;
-        return preg_replace_callback('(\'|")', function($x) { return htmlentities($x[0], ENT_QUOTES); }, $value);
+        $sanitized_value = preg_replace_callback('(\'|")', function($x) { return htmlentities($x[0], ENT_QUOTES); }, $value);
+
+        $scheme = wp_parse_url($sanitized_value, PHP_URL_SCHEME);
+
+        if (!is_null($scheme) && array_search( $scheme, wp_allowed_protocols()) === false) {
+            return '';
+        }
+
+        /**
+         * Filters a string cleaned and escaped for output as a URL.
+         *
+         * @since 2.3.0
+         *
+         * @param string $good_protocol_url The cleaned URL to be returned.
+         * @param string $original_url      The URL prior to cleaning.
+         * @param string $_context          If 'display', replace ampersands and single quotes only.
+         */
+         return apply_filters( 'clean_url', $sanitized_value, $value, 'display' );
     }
-
-
 
     /**
      * Tells if an attribute associated with a Richtext field contains somethings.


### PR DESCRIPTION
Fixes both INC0381599 (by not prepending http:// like #268 unwittingly did), and URLs with escaped slashes (the original issue that #268 attempted to solve). Doesn't break relative URLs.