### PR TITLE
Fix 'EPFL Custom Teaser' and 'EPFL Page Teaser' section title tags

### DIFF
--- a/frontend/epfl-custom-teaser/controller.php
+++ b/frontend/epfl-custom-teaser/controller.php
@@ -39,7 +39,7 @@ function epfl_custom_teaser_block( $attributes ) {
 <div class="container-full p-lg-5 <?php echo $greyClasses ?>">
   <div class="container">
     <?php if ($attributes['titleSection']): ?>
-    <h3 class="h6 mb-3<?php echo ($elementCount < 3) ? ' text-center' : '' ?>"><?php echo $attributes['titleSection'] ?></h3>
+    <h2 class="<?php echo ($elementCount < 3) ? ' text-center' : '' ?>"><?php echo $attributes['titleSection'] ?></h2>
     <?php endif; ?>
     <div class="card-deck<?php echo ($elementCount < 3) ? ' card-deck-line' : '' ?>">
       <?php

--- a/frontend/epfl-page-teaser/controller.php
+++ b/frontend/epfl-page-teaser/controller.php
@@ -50,7 +50,7 @@ function epfl_page_teaser_block( $attributes ) {
     $html .= '<div class="container">';
     if($title != '')
     {
-        $html .= ' <h3 class="h6 mb-3 '. (($pagesCount < 3) ? ' text-center' : ''). '">'.$title.'</h3>';
+        $html .= ' <h2 class="'. (($pagesCount < 3) ? ' text-center' : ''). '">'.$title.'</h2>';
     }
     $html .= '  <div class="card-deck';
     if ($pagesCount < 3) {


### PR DESCRIPTION
Les titres de sections `<h3>` passent en `<h2>` afin de préserver la hiérarchie du contenu.

https://epfl-webvolution.atlassian.net/browse/WEBEVOL-128