### PR TITLE
[feature] Add current time in news URL API REST to avoid being cached

### DIFF
--- a/frontend/epfl-news/controller.php
+++ b/frontend/epfl-news/controller.php
@@ -88,6 +88,10 @@ function epfl_news_build_api_url($channel, $template, $nb_news, $lang, $category
             $url .= '&projects=' . $project['value'];
         }
     }
+
+    // add current time in milliseconds to avoid being cached
+    $url .= '&nocache=' . round(microtime(true) * 1000);
+
     return $url;
 }
 

--- a/plugin.php
+++ b/plugin.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name:     wp-gutenberg-epfl
  * Description:     EPFL Gutenberg Blocks
- * Version:         2.6.0
+ * Version:         2.7.0
  * Author:          WordPress EPFL Team
  * License:         GPL-2.0-or-later
  * License URI:     https://www.gnu.org/licenses/gpl-2.0.html

--- a/src/epfl-news/index.js
+++ b/src/epfl-news/index.js
@@ -10,7 +10,7 @@ import PreviewNews from './preview'
 import InspectorControlsNews from './inspector'
 import './utils.js';
 
-export const version = "v1.1.6";
+export const version = "v1.2.0";
 
 const { __ } = wp.i18n
 const { registerBlockType } = wp.blocks

--- a/src/epfl-news/preview.js
+++ b/src/epfl-news/preview.js
@@ -14,11 +14,18 @@ export default class PreviewNews extends Component {
 		newsUrl: null,
 	}
 
+  getDateTime() {
+    let d = new Date();
+    return d.getMilliseconds();
+  }
+
 	getURL() {
 		const { attributes } = this.props;
 
     let newsUrl = `${BASE_NEWS_API_REST_URL}channels/${attributes.channel}/news/`;
     newsUrl += `?format=json&lang=${attributes.lang}&limit=${attributes.nbNews}`;
+    // add current time in milliseconds to avoid being cached
+    newsUrl += `&nocache=${this.getDateTime()}`;
 
 		if (attributes.category !== 0) {
 			newsUrl += `&category=${attributes.category}`;
@@ -91,7 +98,7 @@ export default class PreviewNews extends Component {
 		const { className, attributes } = this.props
 
 		if (attributes.displayLinkAllNews) {
-      let url = `https://actu.epfl.ch/search/${this.state.channelName}`;
+      let url = `${BASE_NEWS_API_REST_URL}search/${this.state.channelName}`;
 			linkAllNews = (
 				<p className="text-center">
 					<a className="link-pretty" href={ url }>Toutes les actualités</a>

--- a/src/epfl-news/preview.js
+++ b/src/epfl-news/preview.js
@@ -14,18 +14,11 @@ export default class PreviewNews extends Component {
 		newsUrl: null,
 	}
 
-  getDateTime() {
-    let d = new Date();
-    return d.getMilliseconds();
-  }
-
 	getURL() {
 		const { attributes } = this.props;
 
     let newsUrl = `${BASE_NEWS_API_REST_URL}channels/${attributes.channel}/news/`;
     newsUrl += `?format=json&lang=${attributes.lang}&limit=${attributes.nbNews}`;
-    // add current time in milliseconds to avoid being cached
-    newsUrl += `&nocache=${this.getDateTime()}`;
 
 		if (attributes.category !== 0) {
 			newsUrl += `&category=${attributes.category}`;


### PR DESCRIPTION
Le but de cette PR est d'ajouter un paramètre GET à l'appel de l'URL de l'api REST des news, afin que cette URL ne soit pas mis en cache par cloudflare. Ainsi lorsqu'un utilisateur de Médiacom publie une nouvelle news dans l'outil actu qui est destinée à être publié sur www, la news apparaître plus rapidement (temps du cache côté actu = 15 min)

Pour tester:
https://charte-wp.epfl.ch/site1/actualites-non-cachees/
avec l'ajout de l'affichage de l'URL de l'api rest actu pour voir le paramètre nocache=xxxx