### PR TITLE
[fix] Embed of video is only possible from SwitchTube, Vimeo or Youtube

### DIFF
--- a/frontend/epfl-video/controller.php
+++ b/frontend/epfl-video/controller.php
@@ -165,6 +165,10 @@ function epfl_video_block( $attributes ) {
 
     $url = "https://tube.switch.ch/embed/".$video_id;
   }
+  // else if video not [youtube, vimeo, tube.switch] then
+  else {
+    return Utils::render_user_msg("Embed of video is only possible from SwitchTube, Vimeo or Youtube");
+  }
 
   $markup = epfl_video_render($url, $large_display);
   return $markup;

--- a/plugin.php
+++ b/plugin.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name:     wp-gutenberg-epfl
  * Description:     EPFL Gutenberg Blocks
- * Version:         2.12.0
+ * Version:         2.12.1
  * Author:          WordPress EPFL Team
  * License:         GPL-2.0-or-later
  * License URI:     https://www.gnu.org/licenses/gpl-2.0.html


### PR DESCRIPTION
On peut ajouter une vidéo que si elle provient de SwitchTube, Vimeo ou Youtube.
Dans le cas, contraire le msg suivant apparaît :
![image](https://user-images.githubusercontent.com/4997224/119830961-0e3fd600-befd-11eb-951f-fde6a6a7a311.png)

Testé sur wp-dev