### PR TITLE
[feature] add vimeo video

### DIFF
--- a/frontend/epfl-hero/view.php
+++ b/frontend/epfl-hero/view.php
@@ -7,14 +7,25 @@ use \EPFL\Plugins\Gutenberg\Lib\Utils;
 
 require_once(dirname(__FILE__).'/../lib/utils.php');
 
+
+function get_video_id( $video_url ) {
+    $video_id = "";
+    if (!empty($video_url)) {
+      $video_id = end(explode("/", $video_url));
+    }
+    return $video_id;
+}
+
 function epfl_hero_block( $attributes ) {
 
 
     $title       = Utils::get_sanitized_attribute( $attributes, 'title' );
     $image_id    = Utils::get_sanitized_attribute( $attributes, 'imageId' );
     $description = Utils::get_sanitized_attribute( $attributes, 'description' );
+    $video_url   = Utils::get_sanitized_attribute( $attributes, 'videoUrl' );
 
-    $short_vimeo_video_id = "545363021";
+    $short_vimeo_video_id = get_video_id($video_url);
+
     if (!empty($short_vimeo_video_id)) {
       $media_url = "https://player.vimeo.com/video/" . $short_vimeo_video_id . "?autoplay=1&loop=1&muted=1&background=1&quality=720";
     }

--- a/frontend/epfl-hero/view.php
+++ b/frontend/epfl-hero/view.php
@@ -14,6 +14,11 @@ function epfl_hero_block( $attributes ) {
     $image_id    = Utils::get_sanitized_attribute( $attributes, 'imageId' );
     $description = Utils::get_sanitized_attribute( $attributes, 'description' );
 
+    $short_vimeo_video_id = "545363021";
+    if (!empty($short_vimeo_video_id)) {
+      $media_url = "https://player.vimeo.com/video/" . $short_vimeo_video_id . "?autoplay=1&loop=1&muted=1&background=1&quality=720";
+    }
+
     $text = "";
     if (array_key_exists('text', $attributes)) {
       $text = wp_kses_post($attributes['text']);
@@ -43,7 +48,14 @@ if (!empty($text)) { ?>
     </div>
     <div class="hero-img">
       <figure class="cover">
+        <?php
+        if ($media_url) { ?>
+          <div class="embed-responsive embed-responsive-16by9">
+            <iframe src="<?php echo $media_url ?>" frameborder="1"></iframe>
+          </div>
+        <?php } else { ?>
         <picture><?php echo $image; ?></picture>
+        <?php } ?>
         <figcaption>
           <button aria-hidden="true" type="button" class="btn-circle" data-toggle="popover" data-content="<?php echo esc_html($description); ?>">
             <svg class="icon" aria-hidden="true">

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "wp-gutenberg-epfl",
-	"version": "2.13.0",
+	"version": "2.14.0",
 	"description": "Plugin for Wordpress which provides multiple blocks for EPFL services",
 	"author": "WordPress EPFL Team",
 	"license": "GPL-2.0-or-later",

--- a/plugin.php
+++ b/plugin.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name:     wp-gutenberg-epfl
  * Description:     EPFL Gutenberg Blocks
- * Version:         2.13.0
+ * Version:         2.14.0
  * Author:          WordPress EPFL Team
  * License:         GPL-2.0-or-later
  * License URI:     https://www.gnu.org/licenses/gpl-2.0.html

--- a/src/epfl-hero/index.js
+++ b/src/epfl-hero/index.js
@@ -117,7 +117,7 @@ registerBlockType( 'epfl/hero', {
                             label={__('URL of the video', 'epfl')}
                             value={ attributes.videoUrl }
                             onChange={ videoUrl => setAttributes( { videoUrl } ) }
-                            help={ __('You can paste a Vimeo URL', 'epfl') }
+                            help={ __('You can paste a Vimeo URL like https://vimeo.com/339972923', 'epfl') }
                         />
                         <hr/>
                         { ! attributes.imageId ? (

--- a/src/epfl-hero/index.js
+++ b/src/epfl-hero/index.js
@@ -6,7 +6,7 @@ import {
     getTooltippedExample,
 } from '../block-utils.js'
 
-const version = "v1.2.2";
+const version = "v1.3.0";
 
 const { __ } = wp.i18n;
 
@@ -52,6 +52,9 @@ registerBlockType( 'epfl/hero', {
       type: 'number',
     },
     description : {
+      type: 'string',
+    },
+    videoUrl: {
       type: 'string',
     }
 	}),
@@ -108,6 +111,13 @@ registerBlockType( 'epfl/hero', {
                             // setting multiline to something will make the old content unreadable
                             // false -> use <br>
                             multiline={ false }
+                        />
+                        <hr/>
+                        <TextControl
+                            label={__('URL of the video', 'epfl')}
+                            value={ attributes.videoUrl }
+                            onChange={ videoUrl => setAttributes( { videoUrl } ) }
+                            help={ __('You can paste a Vimeo URL', 'epfl') }
                         />
                         <hr/>
                         { ! attributes.imageId ? (


### PR DESCRIPTION
Cette PR a pour but de permettre à l'utilisateur d'ajouter une video vimeo dans un bloc hero (oui ça fait beaucoup de o).
Mais la vidéo vimeo doit s'afficher sans boutons et en mode autoplay comme dans le bloc news.

**Remarque**: Comme pour les vidéos des actus, il faut impérativement que l'utilisateur configure sa video dans vimeo au préalable. Je me souviens que l'on avait fait une doc "Comment configurer la video vimeo ?" mais je ne sais plus où elle ... mais bon ça fait plus de 2ans aussi hein ?!

Voila le nouveau champ permettant de le faire
![image](https://user-images.githubusercontent.com/4997224/123395991-17c26980-d5a1-11eb-9b5c-e63c505c18fa.png)

On récupère l'URL de la video saisie par l'utilisateur, on extrait l'id de la video et on génère une nouvelle url de video du style:
https://player.vimeo.com/video/339972923?autoplay=1&loop=1&muted=1&background=1&quality=720
(comme cela il y pas les boutons et elle en autoplay, etc)

**Remarque**: J'ai pour l'instant laisser les mêmes paramètres que ceux présent dans le video pour le bloc news

Voila le résultat (sur un test fait dans wp-dev)
![image](https://user-images.githubusercontent.com/4997224/123396168-4a6c6200-d5a1-11eb-894e-b8cf146f59c2.png)

Si par contre l'utilisateur met n'importe quoi ou une mauvaise URL dans le champ URL de la video, on obtient cela
![image](https://user-images.githubusercontent.com/4997224/123397988-5822e700-d5a3-11eb-9c43-02a0515b85d9.png)

Si l'utisateur met une video et une image, c'est la video qui est prioritaire.

Test sur wp-dev: https://wp-httpd/schools/test-hero/