### PR TITLE
[feature] epfl-allowed-iframe

### DIFF
--- a/shortcodes/epfl-allowed-iframe/README.md
+++ b/shortcodes/epfl-allowed-iframe/README.md
@@ -1,0 +1,31 @@
+# epfl_allowed_iframe
+
+This shortcode integrate iframes in pages if their source URL is validated based
+on a whitelist.
+
+The whitelist stands in the [allowed_url.txt] file.
+
+
+## URLs validation
+
+The URL validation is done the following way:
+
+1. First, all URLs (both from the shortcode attribute or the whitelist) have to
+   pass the PHP's [FILTER_VALIDATE_URL].
+2. Shortcode's URL has to start with `https`.
+3. `PHP_URL_HOST` from PHP's [parse_url] has to match.
+4. `PHP_URL_PATH` from PHP's [parse_url] have to match.
+
+
+## Usage example
+
+The following shortcode
+```
+[epfl_allowed_iframe url='https://menus.epfl.ch/cgi-bin/getMenus?&midisoir=midi']
+```
+will display the iframe if the whitelist contains the same URL.
+
+
+[allowed_url.txt]: https://github.com/epfl-si/wp-gutenberg-epfl/blob/master/shortcodes/epfl-allowed-iframe/allowed_url.txt
+[FILTER_VALIDATE_URL]: https://www.php.net/manual/en/filter.filters.validate.php
+[parse_url]: https://www.php.net/manual/en/function.parse-url.php

--- a/shortcodes/epfl-allowed-iframe/allowed_url.txt
+++ b/shortcodes/epfl-allowed-iframe/allowed_url.txt
@@ -5,3 +5,5 @@ https://my.matterport.com/show/?m=FSrCT6JAfHs
 https://my.matterport.com/show/?m=prTDR6c7qMh
 https://cede-webapps.epfl.ch/MOOCsCatalog/index.html
 https://edamonitoring.epfl.ch/grafana/d/k1JaxB57k/eda-license-monitor?orgId=1&var-vendor_daemon=cdslmd&var-license_feature=All&var-used_licenses=0&var-used_filter=Currently%20used&from=now-3h&to=now&theme=light&kiosk
+
+# Note: please specify full URL, starting with https://

--- a/shortcodes/epfl-allowed-iframe/allowed_url.txt
+++ b/shortcodes/epfl-allowed-iframe/allowed_url.txt
@@ -1,9 +1,6 @@
 https://energyhub.epfl.ch
-https://my.matterport.com/show/?m=hfxVWe7hzTe
-https://my.matterport.com/show/?m=xP5eFRqd72h
-https://my.matterport.com/show/?m=FSrCT6JAfHs
-https://my.matterport.com/show/?m=prTDR6c7qMh
+https://my.matterport.com/show/
 https://cede-webapps.epfl.ch/MOOCsCatalog/index.html
-https://edamonitoring.epfl.ch/grafana/d/k1JaxB57k/eda-license-monitor?orgId=1&var-vendor_daemon=cdslmd&var-license_feature=All&var-used_licenses=0&var-used_filter=Currently%20used&from=now-3h&to=now&theme=light&kiosk
+https://edamonitoring.epfl.ch/grafana/d/k1JaxB57k/eda-license-monitor
 
 # Note: please specify full URL, starting with https://


### PR DESCRIPTION
* Whitelist import is more robust (use `file` with filter)
* Validate both withelist and shortcode URLs with `FILTER_VALIDATE_URL`
* Same behaviour as before, but the checks now use the PHP's `parse_url`
  function and are more flexible
* Provide the possibility to set a `epfl_allowed_iframe_wildcard` wp option to
  bypass the `PHP_URL_PATH` and `PHP_URL_QUERY`
* Fixes #327 by allowing more that one shortcode on the page
* Provides some reading with the README file