### PR TITLE
Adding a display option slider for the custom data.

### DIFF
--- a/frontend/epfl-people/controller.php
+++ b/frontend/epfl-people/controller.php
@@ -44,9 +44,11 @@ function epfl_people_block( $attributes ) {
     $display_room     = Utils::get_sanitized_attribute( $attributes, 'displayRoom', TRUE );
     $display_email    = Utils::get_sanitized_attribute( $attributes, 'displayEmail', TRUE );
     $display_phone    = Utils::get_sanitized_attribute( $attributes, 'displayPhone', TRUE );
+    $display_custom_data    = Utils::get_sanitized_attribute( $attributes, 'displayCustomData', TRUE );
     $title            = Utils::get_sanitized_attribute( $attributes, 'title');
     $custom_data      = Utils::get_sanitized_attribute( $attributes, 'customData' );
     $filtered_fields  = Utils::get_sanitized_attribute( $attributes, 'filteredFields' );
+
     /*
     var_dump($units);
     var_dump($groups);
@@ -69,7 +71,8 @@ function epfl_people_block( $attributes ) {
       "display_function" => $display_function,
       "display_room" => $display_room,
       "display_email" => $display_email,
-      "display_phone" => $display_phone
+      "display_phone" => $display_phone,
+      "display_custom_data" => $display_custom_data
     );
 
     // Delete all whitespace (including tabs and line ends)

--- a/frontend/epfl-people/templates/includes/dynamic-card-part.inc.php
+++ b/frontend/epfl-people/templates/includes/dynamic-card-part.inc.php
@@ -154,6 +154,8 @@ peoplespace.getCheckBoxGroups = function () {
 peoplespace.getCustomData = function (custom) {
     if (!custom) {
         return '';
+    } else if (!displayFields.includes('display_custom_data')) {
+        return '';
     }
     const customMarkup = custom.map(prop => `<dt>\${prop.key}</dt><dd>\${prop.value}</dd>`);
     return customMarkup.join('');

--- a/src/epfl-people/index.js
+++ b/src/epfl-people/index.js
@@ -76,6 +76,10 @@ registerBlockType(
                 type: 'boolean',
                 default: true,
             },
+            displayCustomData: {
+                type: 'boolean',
+                default: true,
+            },
             title: {
                 type: 'string',
             }

--- a/src/epfl-people/inspector.js
+++ b/src/epfl-people/inspector.js
@@ -135,6 +135,13 @@ export default class InspectorControlsPeople extends Component {
                         checked={ attributes.displayPhone }
                         onChange={ () => setAttributes( { displayPhone: ! attributes.displayPhone } ) }
                     />
+                    {attributes && attributes.columns === '4' &&
+                        <ToggleControl
+                            label={ __('Display custom data', 'epfl') }
+                            checked={ attributes.displayCustomData }
+                            onChange={ () => setAttributes( { displayCustomData: ! attributes.displayCustomData } ) }
+                        />  
+                    }
                 </PanelBody>
                 {attributes && attributes.columns === '4' &&
                     <>


### PR DESCRIPTION

![Screenshot 2022-02-14 at 13 00 05](https://user-images.githubusercontent.com/12231812/153861261-77b0bce8-7b06-4953-98dc-c42dba884460.png)


Hey Guys,

Based on our discussion and feedback from last Friday I'm proposing to incorporate a display slider for the custom data if available (this slider only appears if the custom data template is selected). I was the different options we discussed, but I think this the cleanest and the one that fits the best with the existing sliders. (thanks for the idea @jdelasoie)

Regards,
-Juan