### PR TITLE
Replace moment with dayjs

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
 		"@wordpress/icons": "^2.9.1",
 		"axios": "^0.21.2",
 		"dompurify": "^2.3.5",
-		"moment": "^2.24.0",
+		"dayjs": "^1.10.7",
 		"react": "^17.0.2",
 		"react-dom": "^17.0.2",
 		"react-select": "^5.2.2",

--- a/src/epfl-memento/preview.js
+++ b/src/epfl-memento/preview.js
@@ -1,5 +1,5 @@
 import * as axios from 'axios';
-import moment from 'moment';
+import daysjs from 'daysjs';
 import DOMPurify from 'dompurify';
 
 const { __ } = wp.i18n
@@ -36,7 +36,7 @@ export default class PreviewMemento extends Component {
 		if (attributes.keyword !== '') {
 			eventsUrl += `&keywords=${attributes.keyword}`;
     }
-    
+
     if (attributes.period === 'past' && attributes.year !== 'no-filter') {
       eventsUrl += `&start_year=${attributes.year}`;
     }
@@ -140,22 +140,22 @@ export default class PreviewMemento extends Component {
 
           let startDate;
           if (!!event.start_date) {
-            startDate = <span className="card-info-date" itemProp="startDate">{moment(event.start_date).format("DD-MM-YYYY")}</span>
+            startDate = <span className="card-info-date" itemProp="startDate">{daysjs(event.start_date).format("DD-MM-YYYY")}</span>
           }
 
           let startTime;
           if (!!event.start_time) {
-            startTime = <span className="event-time">{ moment(event.start_time,'h:mm').format('h:mm') }</span>
+            startTime = <span className="event-time">{ daysjs(event.start_time,'h:mm').format('h:mm') }</span>
           }
 
           let endTime;
           if (!!event.end_time) {
-            endTime = <span className="event-time">{ moment(event.end_time,'h:mm').format('h:mm') }</span>
+            endTime = <span className="event-time">{ daysjs(event.end_time,'h:mm').format('h:mm') }</span>
           }
 
           let endDate;
           if (!!event.end_date) {
-            endDate = <span className="card-info-date" itemProp="endDate">{moment(event.end_date).format("DD-MM-YYYY")}</span>
+            endDate = <span className="card-info-date" itemProp="endDate">{daysjs(event.end_date).format("DD-MM-YYYY")}</span>
           }
 
           let category;

--- a/src/epfl-news/preview.js
+++ b/src/epfl-news/preview.js
@@ -1,6 +1,6 @@
 import * as axios from 'axios';
 import stripHtml from "string-strip-html";
-import moment from 'moment';
+import daysjs from 'daysjs';
 
 const { __ } = wp.i18n
 const { Spinner } = wp.components
@@ -119,7 +119,7 @@ export default class PreviewNews extends Component {
 									<div className="list-group-teaser-content" itemScope itemType="http://schema.org/Article">
 										<p className="h5" itemProp="name">{ news.title }</p>
 										<p>
-											<time dateTime={ news.publish_date } itemProp="datePublished">{ moment(news.publish_date).format('MM.DD.YYYY') }</time>
+											<time dateTime={ news.publish_date } itemProp="datePublished">{ daysjs(news.publish_date).format('MM.DD.YYYY') }</time>
 											<span className="text-muted" itemProp="description"> — { stripHtml(news.subtitle) }</span>
 										</p>
 									</div>


### PR DESCRIPTION
Asked by many:
https://www.npmjs.com/package/moment
https://momentjs.com/docs/#/-project-status/
https://twitter.com/addyosmani/status/1304676118822174721

Not tested at the moment, but as the lib is used only to format some field, the change should not be a heart breaking one.