### PR TITLE
Simplify dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,24 +20,16 @@
 		"url": "https://github.com/epfl-si/wp-gutenberg-epfl/issues"
 	},
 	"main": "build/index.js",
-	"dependencies": {
-		"@wordpress/icons": "^2.9.1",
-		"axios": "^0.21.2",
-		"dompurify": "^2.3.5",
-		"moment": "^2.24.0",
-		"react": "^17.0.2",
-		"react-dom": "^17.0.2",
-		"react-select": "^5.2.2",
-		"string-strip-html": "4.0.12"
-	},
 	"devDependencies": {
 		"@wordpress/babel-plugin-makepot": "^4.0.1",
+		"@wordpress/icons": "^2.9.1",
 		"@wordpress/scripts": "^21.0.1",
-		"eslint": "^8.9.0",
+		"axios": "^0.25.0",
+		"dompurify": "^2.3.5",
+		"moment": "^2.24.0",
 		"po2json": "^0.4.5",
-		"postcss": "^8.4.6",
-		"prettier": "^2.1.1",
-		"typescript": "^4.0.2"
+		"react-select": "^5.2.2",
+		"string-strip-html": "4.0.12"
 	},
 	"scripts": {
 		"build": "npx wp-scripts build",


### PR DESCRIPTION
Remove already declared dependencies in @wordpress/scripts without a declared usage
Update axios to the same version as @wordpress/scripts