### PR TITLE
fix Undefined variable $media_url when video is not provided

### DIFF
--- a/frontend/epfl-hero/view.php
+++ b/frontend/epfl-hero/view.php
@@ -60,7 +60,7 @@ if (!empty($text)) { ?>
     <div class="hero-img">
       <figure class="cover">
         <?php
-        if ($media_url) { ?>
+        if (isset($media_url) && ($media_url!==null)) { ?>
           <div class="embed-responsive embed-responsive-16by9">
             <iframe src="<?php echo $media_url ?>" frameborder="1"></iframe>
           </div>


### PR DESCRIPTION
When adding a Hero block without video : 

`Warning: Undefined variable $media_url in ..../wp-content/plugins/wp-gutenberg-epfl/frontend/epfl-hero/view.php on line 63`