### PR TITLE
[feat] add option for sorting people randomly

### DIFF
--- a/frontend/epfl-people/controller.php
+++ b/frontend/epfl-people/controller.php
@@ -137,7 +137,7 @@ function epfl_people_block( $attributes ) {
         }
         $parameter['struct'] = $structure;
     } else {
-        $order = ALPHABETICAL_ORDER;
+        if (RANDOM_ORDER !== $order) $order = ALPHABETICAL_ORDER;
     }
 
     if (function_exists('pll_current_language')) {
@@ -177,7 +177,12 @@ function epfl_people_block( $attributes ) {
         $persons = epfl_people_sortArrayByArray($persons, $scipers);
     } else if ("" !== $units || "" !== $doctoral_program || "" !== $groups) {
         // Sort persons list alphabetically when units, doctoral program or groups
-        usort($persons, __NAMESPACE__.'\epfl_people_person_compare');
+        if (RANDOM_ORDER === $order) {
+            shuffle($persons);
+            $order = ALPHABETICAL_ORDER;
+        } else {
+            usort($persons, __NAMESPACE__.'\epfl_people_person_compare');
+        }
     }
 
     $markup = epfl_people_render($persons, $from, $columns, $order, $title, $display_options, $custom_data, $filtered_fields);

--- a/frontend/epfl-people/utils.php
+++ b/frontend/epfl-people/utils.php
@@ -7,6 +7,7 @@ use function EPFL\Plugins\Gutenberg\Lib\Language\get_current_or_default_language
 define(__NAMESPACE__ . "\HIERARCHICAL_ORDER", "hierarchical");
 define(__NAMESPACE__ . "\HIERARCHICAL_ORDER_WITH_TITLE", "hierarchical-with-title");
 define(__NAMESPACE__ . "\ALPHABETICAL_ORDER", "alphabetical");
+define(__NAMESPACE__ . "\RANDOM_ORDER", "random");
 
 /**
  * Delete duplicate entry from array

--- a/src/epfl-people/inspector.js
+++ b/src/epfl-people/inspector.js
@@ -36,6 +36,7 @@ export default class InspectorControlsPeople extends Component {
           { value: 'alphabetical', label: __('Alphabetical order', 'epfl')},
           { value: 'hierarchical', label: __('Hierarchical order', 'epfl')},
           { value: 'hierarchical-with-title', label: __('Hierarchical order with title', 'epfl')},
+          { value: 'random', label: __('Random order', 'epfl')},
         ]
 
         let structure;


### PR DESCRIPTION
Adds the option for sorting the people cards in random order unless the list of sciper is provided explicitly in which case the input order is respected. This does not include (yet) a random sub-sorting within hierarchical sorting.
Since the randomization is done on the server, due to caching it will not be as dynamic as expected and the improvement in _equal opportunity_ quite limited to observations over long time intervals.  
In fact, I have written this mostly as an exercise to get in touch with our wp-dev. Therefore, feel free to reject it.

giova