### PR TITLE
[fix] Explicit loading of the .mo file

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -29,7 +29,7 @@ require_once plugin_dir_path( __FILE__ ) . 'frontend/init.php';
 // load .mo file for translation
 function epfl_gutenberg_load_textdomain() {
     $domain = 'epfl';
-	$locale = pll_current_language( 'locale' );
+    $locale = pll_current_language( 'locale' );
     $mo_file = plugin_dir_path( __FILE__ ) . "languages/{$domain}-{$locale}.mo";
 
     if ( file_exists( $mo_file ) ) {

--- a/plugin.php
+++ b/plugin.php
@@ -3,7 +3,7 @@
 /**
  * Plugin Name:     wp-gutenberg-epfl
  * Description:     EPFL Gutenberg Blocks
- * Version:         2.41.1
+ * Version:         2.42.0
  * Author:          WordPress EPFL Team
  * License:         GPL-2.0-or-later
  * License URI:     https://www.gnu.org/licenses/gpl-2.0.html
@@ -28,10 +28,17 @@ require_once plugin_dir_path( __FILE__ ) . 'frontend/init.php';
 
 // load .mo file for translation
 function epfl_gutenberg_load_textdomain() {
-	load_plugin_textdomain( 'epfl', false, basename( dirname( __FILE__ ) ) . '/languages/' );
+    $domain = 'epfl';
+	$locale = pll_current_language( 'locale' );
+    $mo_file = plugin_dir_path( __FILE__ ) . "languages/{$domain}-{$locale}.mo";
+
+    if ( file_exists( $mo_file ) ) {
+        unload_textdomain( $domain );
+        $loaded = load_textdomain( $domain, $mo_file );
+    }
 }
 
-add_action( 'plugins_loaded', __NAMESPACE__ . '\epfl_gutenberg_load_textdomain' );
+add_action( 'wp', __NAMESPACE__ . '\epfl_gutenberg_load_textdomain', 20 );
 
 # allow to fetch rest api with the lang parameter
 function polylang_json_api_init() {


### PR DESCRIPTION
https://erpdev.atlassian.net/browse/WPN-388

- get the current language of the page
- loads the .mo language instead of the directory

Alternative solution : change the path of the .mo and .po wp-content/languages/plugins  https://developer.wordpress.org/plugins/internationalization/localization/#using-localizations