### PR TITLE
[feature] Support YouTube Shorts and vertical display format

### DIFF
--- a/frontend/epfl-video/controller.php
+++ b/frontend/epfl-video/controller.php
@@ -132,34 +132,48 @@ function epfl_video_block( $attributes ) {
         Utils::render_user_msg('You must activate the epfl theme');
     }
 
-    /* Extracting query string */
-    $query = parse_url($url, PHP_URL_QUERY);
+      $video_id = '';
+      $query_args = [];
 
-    parse_str($query, $query_args);
-
-    $video_id = $query_args['v'];
-    /* Removing video ID from query string */
-    unset($query_args['v']);
-
-    /* If we have a time at which to start video */
-    if(array_key_exists('t', $query_args))
+    // Check if it is a YouTube Short.
+    if ( preg_match( '/\/shorts\/([a-zA-Z0-9_-]+)/', $url, $shorts_matches ) )
     {
-        /* When video is embed, the parameters is called 'start' and not 't', so we remove the incorrect one
-        and add the new one. */
-        $query_args['start'] = $query_args['t'];
-        unset($query_args['t']);
+        $video_id = $shorts_matches[1];
+
+        $query_str = parse_url( $url, PHP_URL_QUERY );
+        if ( $query_str )
+        {
+            parse_str( $query_str, $query_args );
+        }
+    }
+    else
+    {
+    	// Standard YouTube URL.
+        $query_str = parse_url( $url, PHP_URL_QUERY );
+        parse_str( $query_str, $query_args );
+        $video_id = isset( $query_args['v'] ) ? $query_args['v'] : '';
+        unset( $query_args['v'] );
     }
 
-    /* We remove existing query string from URL */
-    $url = str_replace('?'.$query, '', $url);
-
-    /* Updating query (without video_id if it was present) to reuse it later */
-    $query = http_build_query($query_args);
-
-    $url = "https://www.youtube.com/embed/".$video_id;
-    if($query != "")
+    if ( empty( $video_id ) )
     {
-        $url .= '?'.$query;
+    	return Utils::render_user_msg( "ID YouTube introuvable" );
+    }
+
+    /* If we have a time at which to start video */
+    if( isset( $query_args['t'] ) )
+    {
+        $query_args['start'] = str_replace( 's', '', $query_args['t'] );
+        unset( $query_args['t'] );
+    }
+
+      // RECONSTRUCTION PROPRE : On ne touche plus à l'ancienne variable $url
+    $clean_query = http_build_query( $query_args );
+    $url = "https://www.youtube.com/embed/" . $video_id;
+
+    if( !empty( $clean_query ) )
+    {
+    	$url .= '?' . $clean_query;
     }
   }
 

--- a/frontend/epfl-video/view.php
+++ b/frontend/epfl-video/view.php
@@ -71,18 +71,23 @@ function epfl_video_kaltura_render(
  * Returns HTML code to display browser native video player
  *
  * @param String $url Video URL
- * @param String $display_type Should be'standard', 'large' or 'full'
+ * @param String $display_type Should be'standard', 'large', 'full' or 'vertical'
  */
 function epfl_video_render($url, $display_type) {
     $classes = ['my-3'];
+    $ratio_class = "embed-responsive-16by9";
 
     if($display_type == 'large') $classes[] = "container";
     if($display_type == 'full') $classes[] = "container-full";
+    if( $display_type == 'vertical' ) {
+        $classes[] = "is-vertical";
+        $ratio_class = ""; // On enlève le 16by9 pour laisser le CSS gérer le 9:16
+    }
 
     ob_start();
 ?>
 <div class="<?php echo implode(" ", $classes) ?>">
-    <div class="embed-responsive embed-responsive-16by9">
+    <div class="embed-responsive <?php echo $ratio_class; ?>">
         <iframe src="<?php echo esc_url($url); ?>" webkitallowfullscreen mozallowfullscreen allowfullscreen allow="autoplay; encrypted-media" frameborder="0" class="embed-responsive-item"></iframe>
     </div>
 </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "wp-gutenberg-epfl",
-	"version": "2.51.0",
+	"version": "2.52.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "wp-gutenberg-epfl",
-			"version": "2.51.0",
+			"version": "2.52.0",
 			"license": "GPL-2.0-or-later",
 			"devDependencies": {
 				"@wordpress/babel-plugin-makepot": "^5.27.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "wp-gutenberg-epfl",
-	"version": "2.51.0",
+	"version": "2.52.0",
 	"description": "Plugin for Wordpress which provides multiple blocks for EPFL services",
 	"author": "WordPress EPFL Team",
 	"license": "GPL-2.0-or-later",

--- a/plugin.php
+++ b/plugin.php
@@ -3,7 +3,7 @@
 /**
  * Plugin Name:     wp-gutenberg-epfl
  * Description:     EPFL Gutenberg Blocks
- * Version:         2.51.0
+ * Version:         2.52.0
  * Author:          WordPress EPFL Team
  * License:         GPL-2.0-or-later
  * License URI:     https://www.gnu.org/licenses/gpl-2.0.html

--- a/src/epfl-video/index.js
+++ b/src/epfl-video/index.js
@@ -74,6 +74,7 @@ registerBlockType( 'epfl/video', {
 								{ label: 'Standard', value: 'standard' },
 								{ label: 'Large', value: 'large' },
 								{ label: 'Full', value: 'full' },
+								{ label: 'Vertical', value: 'vertical'}
 							] }
 							onChange={ ( displayType ) => setAttributes( { displayType } ) }
                         />

--- a/src/epfl-video/index.js
+++ b/src/epfl-video/index.js
@@ -6,7 +6,7 @@ import {
 
 import videoIcon from './video-icon'
 
-const version = "v1.5.0";
+const version = "v1.6.0";
 
 const { __ } = wp.i18n;
 

--- a/src/style.scss
+++ b/src/style.scss
@@ -73,3 +73,13 @@ $red: orangered;
 .bigger-font-size-table > figure.wp-block-table > table {
   font-size: 100%;
 }
+
+.is-vertical {
+    display: flex !important;
+    justify-content: center;
+    width: 100% !important;
+    aspect-ratio: 9 / 16 !important;
+    padding-bottom: 0 !important;
+    height: auto !important;
+    margin: 0 auto;
+}


### PR DESCRIPTION
- Add a new 'Vertical' option to the display settings in the Gutenberg block.
- Update PHP rendering to include 'is-vertical' class and handle 9:16 aspect ratio.